### PR TITLE
Fix borrow bug and normal distribution import

### DIFF
--- a/src/core/vector.rs
+++ b/src/core/vector.rs
@@ -36,7 +36,7 @@ impl Vector {
     }
     
     pub fn random_normal(dimensions: usize, mean: f32, std_dev: f32) -> Self {
-        use rand::distributions::{Distribution, Normal};
+        use rand_distr::{Distribution, Normal};
         let normal = Normal::new(mean as f64, std_dev as f64).unwrap();
         let mut rng = rand::thread_rng();
         let values = (0..dimensions)

--- a/src/nerv/synchrony.rs
+++ b/src/nerv/synchrony.rs
@@ -48,7 +48,8 @@ impl SynchronyManager {
     
     pub async fn increment_local_clock(&self) -> u64 {
         let mut state = self.state.write().await;
-        let counter = state.clock.entry(state.node_id.clone()).or_insert(0);
+        let node_id = state.node_id.clone();
+        let counter = state.clock.entry(node_id).or_insert(0);
         *counter += 1;
         *counter
     }


### PR DESCRIPTION
## Summary
- fix use of `rand_distr::Normal`
- resolve a borrow checker error in synchrony clock update

## Testing
- `cargo test --all --quiet` *(fails: could not compile `amazon-rose-forest`)*

------
https://chatgpt.com/codex/tasks/task_e_6843227584c88331bec9f72aff135fd8