### PR TITLE
Add warp dependency and import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ prometheus = "0.13"
 once_cell = "1.18.0"
 rand_distr = "0.4.3"
 sha2 = "0.10.7"  # Added SHA-2 cryptographic hash functions
+warp = "0.3"
 
 # Holochain dependencies
 hdk = "0.1.0"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,6 +5,7 @@ use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use anyhow::{Result, anyhow};
 use tracing::{info, error, debug, warn};
+use warp;
 
 use crate::core::metrics::MetricsCollector;
 use crate::nerv::runtime::Runtime;


### PR DESCRIPTION
## Summary
- add Warp web framework to dependencies
- import Warp in server module

## Testing
- `cargo check` *(fails: could not compile `amazon-rose-forest`)*

------
https://chatgpt.com/codex/tasks/task_e_6843372b8bdc83319f3d82829412b964