### PR TITLE
Fix HashMap import placement

### DIFF
--- a/src/darwin/self_improvement.rs
+++ b/src/darwin/self_improvement.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::collections::HashMap;
 use tokio::sync::RwLock;
 use anyhow::{Result, anyhow};
 use tracing::{info, warn, error, debug};
@@ -406,6 +407,3 @@ impl Clone for SelfImprovementEngine {
         }
     }
 }
-
-// Add missing HashMap import
-use std::collections::HashMap;


### PR DESCRIPTION
## Summary
- move `HashMap` import to import block in `self_improvement.rs`
- remove stray comment and maintain trailing newline

## Testing
- `cargo check` *(fails: unresolved crates and unstable features)*

------
https://chatgpt.com/codex/tasks/task_e_684336fa80dc833199edd6e3291cbb19