### PR TITLE
Fix missing uuid import

### DIFF
--- a/src/holochain/arbitration.rs
+++ b/src/holochain/arbitration.rs
@@ -6,6 +6,7 @@ use crate::holochain::entries::{
 };
 use crate::holochain::utils::{sys_time, create_path, timestamp_tag};
 use std::collections::HashMap;
+use uuid::Uuid;
 
 /// Input for conflict arbitration
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
## Summary
- bring Uuid into scope for arbitration

## Testing
- `cargo test --quiet` *(fails: unresolved crate `warp`, unstable portable_simd, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684337277c108331a8a5f95db58c8f74