### PR TITLE
Move rand import to top of exploration module

### DIFF
--- a/src/darwin/exploration.rs
+++ b/src/darwin/exploration.rs
@@ -4,6 +4,7 @@ use tracing::{info, warn, error, debug};
 use uuid::Uuid;
 use tokio::sync::RwLock;
 use std::collections::{HashMap, HashSet};
+use rand::prelude::*;
 
 use crate::darwin::self_improvement::Modification;
 use crate::core::metrics::MetricsCollector;
@@ -605,5 +606,3 @@ pub struct ArchiveStats {
     pub top_scores: Vec<(Uuid, f32)>,
 }
 
-// Add missing imports
-use rand::prelude::*;


### PR DESCRIPTION
## Summary
- tidy `src/darwin/exploration.rs` imports

## Testing
- `cargo check` *(fails: unresolved crates and unstable features)*

------
https://chatgpt.com/codex/tasks/task_e_68433704acf48331b20abc7abc3dd96a