### PR TITLE
Fix time unwrap in VectorEntry conversion

### DIFF
--- a/src/holochain/mod.rs
+++ b/src/holochain/mod.rs
@@ -31,7 +31,7 @@ impl From<Vector> for VectorEntry {
             values: vector.values.clone(),
             dimensions: vector.dimensions,
             metadata: None,
-            created_at: sys_time()?,
+            created_at: sys_time().unwrap_or(0),
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid `?` when setting `VectorEntry`'s `created_at`

## Testing
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings` *(fails: unresolved imports and unused code)*
- `cargo build --verbose` *(fails: multiple compile errors)*
- `cargo test --verbose` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843372ad5c08331a14f7e52e3e0ae84