### PR TITLE
Add warp dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ petgraph = "0.6.3"
 nalgebra = "0.32.2"
 opentelemetry = "0.19.0"
 opentelemetry-otlp = "0.12.0"
+warp = "0.3"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Amazon Rose Forest integrates with Holochain to provide:
 
 ## Development
 
+### Dependencies
+
+- `warp` 0.3 is used for the HTTP API layer.
+
 ### Building
 
 ```bash


### PR DESCRIPTION
## Summary
- add `warp` to dependencies
- document the new dependency in the development section

## Testing
- `cargo build` *(fails: unresolved imports and unstable feature usage)*

------
https://chatgpt.com/codex/tasks/task_e_68434d0966f08331993f2cb7b0109a12