### PR TITLE
Add rand_distr dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "0.4", features = ["serde"] }
 hashbrown = "0.14"
 prometheus = "0.13"
 once_cell = "1.18.0"
-rand_distr = "0.4.3"
+rand_distr = "0.4"
 sha2 = "0.10.7"  # Added SHA-2 cryptographic hash functions
 
 # Holochain dependencies

--- a/src/core/vector.rs
+++ b/src/core/vector.rs
@@ -36,7 +36,7 @@ impl Vector {
     }
     
     pub fn random_normal(dimensions: usize, mean: f32, std_dev: f32) -> Self {
-        use rand::distributions::{Distribution, Normal};
+        use rand_distr::{Distribution, Normal};
         let normal = Normal::new(mean as f64, std_dev as f64).unwrap();
         let mut rng = rand::thread_rng();
         let values = (0..dimensions)


### PR DESCRIPTION
## Summary
- add the `rand_distr` crate in `Cargo.toml`
- adjust the `random_normal` helper to import from `rand_distr`

## Testing
- `cargo test` *(fails: use of unstable features and missing crates)*

------
https://chatgpt.com/codex/tasks/task_e_68434d1a061c8331a4d1b932c8f62f70