### PR TITLE
Resolve borrow checker issue in synchrony manager

### DIFF
--- a/src/nerv/synchrony.rs
+++ b/src/nerv/synchrony.rs
@@ -48,8 +48,8 @@ impl SynchronyManager {
     
     pub async fn increment_local_clock(&self) -> u64 {
         let mut state = self.state.write().await;
-        let node_id = state.node_id.clone();
-        let counter = state.clock.entry(node_id).or_insert(0);
+        let node = state.node_id.clone();
+        let counter = state.clock.entry(node).or_insert(0);
 
         *counter += 1;
         *counter

--- a/src/nerv/synchrony.rs
+++ b/src/nerv/synchrony.rs
@@ -48,7 +48,8 @@ impl SynchronyManager {
     
     pub async fn increment_local_clock(&self) -> u64 {
         let mut state = self.state.write().await;
-        let counter = state.clock.entry(state.node_id.clone()).or_insert(0);
+        let node = state.node_id.clone();
+        let counter = state.clock.entry(node).or_insert(0);
         *counter += 1;
         *counter
     }

--- a/src/nerv/synchrony.rs
+++ b/src/nerv/synchrony.rs
@@ -48,8 +48,8 @@ impl SynchronyManager {
     
     pub async fn increment_local_clock(&self) -> u64 {
         let mut state = self.state.write().await;
-        let node = state.node_id.clone();
-        let counter = state.clock.entry(node).or_insert(0);
+        let node_id = state.node_id.clone();
+        let counter = state.clock.entry(node_id).or_insert(0);
 
         *counter += 1;
         *counter


### PR DESCRIPTION
## Summary
- fix borrow checker error in `increment_local_clock`

## Testing
- `cargo check` *(fails: unresolved crates and unstable features)*

------
https://chatgpt.com/codex/tasks/task_e_68434d223aa08331862901ed319bb78b