### PR TITLE
Fix borrow issues in exploration and ritual modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ prometheus = "0.13"
 once_cell = "1.18.0"
 rand_distr = "0.4.3"
 sha2 = "0.10.7"  # Added SHA-2 cryptographic hash functions
+warp = "0.3"
 
 # Holochain dependencies
 hdk = "0.1.0"

--- a/src/core/vector.rs
+++ b/src/core/vector.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, Div, Mul, Sub};
-use std::simd::{f32x4, mask32x4, StdFloat};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Vector {
@@ -13,30 +12,30 @@ impl Vector {
         let dimensions = values.len();
         Self { dimensions, values }
     }
-    
+
     pub fn zeros(dimensions: usize) -> Self {
         Self {
             dimensions,
             values: vec![0.0; dimensions],
         }
     }
-    
+
     pub fn ones(dimensions: usize) -> Self {
         Self {
             dimensions,
             values: vec![1.0; dimensions],
         }
     }
-    
+
     pub fn random(dimensions: usize) -> Self {
         use rand::Rng;
         let mut rng = rand::thread_rng();
         let values = (0..dimensions).map(|_| rng.gen::<f32>()).collect();
         Self { dimensions, values }
     }
-    
+
     pub fn random_normal(dimensions: usize, mean: f32, std_dev: f32) -> Self {
-        use rand::distributions::{Distribution, Normal};
+        use rand_distr::{Distribution, Normal};
         let normal = Normal::new(mean as f64, std_dev as f64).unwrap();
         let mut rng = rand::thread_rng();
         let values = (0..dimensions)
@@ -44,131 +43,109 @@ impl Vector {
             .collect();
         Self { dimensions, values }
     }
-    
+
     pub fn dot(&self, other: &Vector) -> f32 {
-        assert_eq!(self.dimensions, other.dimensions, "Vectors must have the same dimensions");
-        
-        // Use SIMD acceleration for vectors with dimensions divisible by 4
-        if self.dimensions % 4 == 0 {
-            self.dot_simd(other)
-        } else {
-            self.dot_scalar(other)
-        }
+        assert_eq!(
+            self.dimensions, other.dimensions,
+            "Vectors must have the same dimensions"
+        );
+
+        self.dot_scalar(other)
     }
-    
+
     fn dot_scalar(&self, other: &Vector) -> f32 {
-        self.values.iter().zip(other.values.iter()).map(|(a, b)| a * b).sum()
+        self.values
+            .iter()
+            .zip(other.values.iter())
+            .map(|(a, b)| a * b)
+            .sum()
     }
-    
-    fn dot_simd(&self, other: &Vector) -> f32 {
-        let chunks = self.dimensions / 4;
-        let mut sum = f32x4::splat(0.0);
-        
-        for i in 0..chunks {
-            let start = i * 4;
-            let a = f32x4::from_slice(&self.values[start..start + 4]);
-            let b = f32x4::from_slice(&other.values[start..start + 4]);
-            sum += a * b;
-        }
-        
-        sum.horizontal_sum()
-    }
-    
+
     pub fn magnitude(&self) -> f32 {
         self.dot(self).sqrt()
     }
-    
+
     pub fn normalize(&self) -> Self {
         let mag = self.magnitude();
         if mag == 0.0 {
             return self.clone();
         }
-        
+
         let values = self.values.iter().map(|v| v / mag).collect();
         Self {
             dimensions: self.dimensions,
             values,
         }
     }
-    
+
     pub fn cosine_similarity(&self, other: &Vector) -> f32 {
         let dot_product = self.dot(other);
         let magnitude_product = self.magnitude() * other.magnitude();
-        
+
         if magnitude_product == 0.0 {
             return 0.0;
         }
-        
+
         dot_product / magnitude_product
     }
-    
+
     pub fn euclidean_distance(&self, other: &Vector) -> f32 {
-        assert_eq!(self.dimensions, other.dimensions, "Vectors must have the same dimensions");
-        
-        // Use SIMD acceleration for vectors with dimensions divisible by 4
-        if self.dimensions % 4 == 0 {
-            self.euclidean_distance_simd(other)
-        } else {
-            self.euclidean_distance_scalar(other)
-        }
+        assert_eq!(
+            self.dimensions, other.dimensions,
+            "Vectors must have the same dimensions"
+        );
+
+        self.euclidean_distance_scalar(other)
     }
-    
+
     fn euclidean_distance_scalar(&self, other: &Vector) -> f32 {
-        let sum_squared_diff: f32 = self.values
+        let sum_squared_diff: f32 = self
+            .values
             .iter()
             .zip(other.values.iter())
             .map(|(a, b)| (a - b).powi(2))
             .sum();
-            
+
         sum_squared_diff.sqrt()
     }
-    
-    fn euclidean_distance_simd(&self, other: &Vector) -> f32 {
-        let chunks = self.dimensions / 4;
-        let mut sum = f32x4::splat(0.0);
-        
-        for i in 0..chunks {
-            let start = i * 4;
-            let a = f32x4::from_slice(&self.values[start..start + 4]);
-            let b = f32x4::from_slice(&other.values[start..start + 4]);
-            let diff = a - b;
-            sum += diff * diff;
-        }
-        
-        sum.horizontal_sum().sqrt()
-    }
-    
+
     pub fn manhattan_distance(&self, other: &Vector) -> f32 {
-        assert_eq!(self.dimensions, other.dimensions, "Vectors must have the same dimensions");
-        
+        assert_eq!(
+            self.dimensions, other.dimensions,
+            "Vectors must have the same dimensions"
+        );
+
         self.values
             .iter()
             .zip(other.values.iter())
             .map(|(a, b)| (a - b).abs())
             .sum()
     }
-    
+
     pub fn hamming_distance(&self, other: &Vector) -> usize {
-        assert_eq!(self.dimensions, other.dimensions, "Vectors must have the same dimensions");
-        
+        assert_eq!(
+            self.dimensions, other.dimensions,
+            "Vectors must have the same dimensions"
+        );
+
         self.values
             .iter()
             .zip(other.values.iter())
             .filter(|(&a, &b)| (a - b).abs() > f32::EPSILON)
             .count()
     }
-    
+
     pub fn batch_process<F>(&self, others: &[Vector], f: F) -> Vec<f32>
     where
         F: Fn(&Vector, &Vector) -> f32,
     {
         others.iter().map(|other| f(self, other)).collect()
     }
-    
+
     pub fn batch_cosine_similarity(&self, others: &[Vector]) -> Vec<f32> {
         self.batch_process(others, |a, b| a.cosine_similarity(b))
     }
-    
+
     pub fn batch_euclidean_distance(&self, others: &[Vector]) -> Vec<f32> {
         self.batch_process(others, |a, b| a.euclidean_distance(b))
     }
@@ -176,16 +153,20 @@ impl Vector {
 
 impl Add for Vector {
     type Output = Self;
-    
+
     fn add(self, other: Self) -> Self::Output {
-        assert_eq!(self.dimensions, other.dimensions, "Vectors must have the same dimensions");
-        
-        let values = self.values
+        assert_eq!(
+            self.dimensions, other.dimensions,
+            "Vectors must have the same dimensions"
+        );
+
+        let values = self
+            .values
             .iter()
             .zip(other.values.iter())
             .map(|(a, b)| a + b)
             .collect();
-            
+
         Self {
             dimensions: self.dimensions,
             values,
@@ -195,16 +176,20 @@ impl Add for Vector {
 
 impl Sub for Vector {
     type Output = Self;
-    
+
     fn sub(self, other: Self) -> Self::Output {
-        assert_eq!(self.dimensions, other.dimensions, "Vectors must have the same dimensions");
-        
-        let values = self.values
+        assert_eq!(
+            self.dimensions, other.dimensions,
+            "Vectors must have the same dimensions"
+        );
+
+        let values = self
+            .values
             .iter()
             .zip(other.values.iter())
             .map(|(a, b)| a - b)
             .collect();
-            
+
         Self {
             dimensions: self.dimensions,
             values,
@@ -214,10 +199,10 @@ impl Sub for Vector {
 
 impl Mul<f32> for Vector {
     type Output = Self;
-    
+
     fn mul(self, scalar: f32) -> Self::Output {
         let values = self.values.iter().map(|v| v * scalar).collect();
-        
+
         Self {
             dimensions: self.dimensions,
             values,
@@ -227,12 +212,12 @@ impl Mul<f32> for Vector {
 
 impl Div<f32> for Vector {
     type Output = Self;
-    
+
     fn div(self, scalar: f32) -> Self::Output {
         assert!(scalar != 0.0, "Cannot divide by zero");
-        
+
         let values = self.values.iter().map(|v| v / scalar).collect();
-        
+
         Self {
             dimensions: self.dimensions,
             values,
@@ -243,63 +228,63 @@ impl Div<f32> for Vector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_vector_operations() {
         let v1 = Vector::new(vec![1.0, 2.0, 3.0]);
         let v2 = Vector::new(vec![4.0, 5.0, 6.0]);
-        
+
         // Test addition
         let v_sum = v1.clone() + v2.clone();
         assert_eq!(v_sum.values, vec![5.0, 7.0, 9.0]);
-        
+
         // Test subtraction
         let v_diff = v2.clone() - v1.clone();
         assert_eq!(v_diff.values, vec![3.0, 3.0, 3.0]);
-        
+
         // Test scalar multiplication
         let v_scaled = v1.clone() * 2.0;
         assert_eq!(v_scaled.values, vec![2.0, 4.0, 6.0]);
-        
+
         // Test dot product
         let dot = v1.dot(&v2);
         assert_eq!(dot, 1.0 * 4.0 + 2.0 * 5.0 + 3.0 * 6.0);
-        
+
         // Test magnitude
         let mag = v1.magnitude();
         assert!((mag - (1.0f32 + 4.0 + 9.0).sqrt()).abs() < 1e-6);
-        
+
         // Test normalization
         let v_norm = v1.normalize();
         let expected_mag = 1.0;
         assert!((v_norm.magnitude() - expected_mag).abs() < 1e-6);
     }
-    
+
     #[test]
     fn test_distance_metrics() {
         let v1 = Vector::new(vec![1.0, 2.0, 3.0]);
         let v2 = Vector::new(vec![4.0, 5.0, 6.0]);
-        
+
         // Test Euclidean distance
         let euclidean = v1.euclidean_distance(&v2);
         assert!((euclidean - ((3.0 * 3.0 + 3.0 * 3.0 + 3.0 * 3.0) as f32).sqrt()).abs() < 1e-6);
-        
+
         // Test Manhattan distance
         let manhattan = v1.manhattan_distance(&v2);
         assert_eq!(manhattan, 9.0);
-        
+
         // Test Hamming distance
         let hamming = v1.hamming_distance(&v2);
         assert_eq!(hamming, 3);
-        
+
         // Test cosine similarity
         let cosine = v1.cosine_similarity(&v2);
-        let expected = (1.0 * 4.0 + 2.0 * 5.0 + 3.0 * 6.0) / 
-                      ((1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0).sqrt() * 
-                       (4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0).sqrt());
+        let expected = (1.0 * 4.0 + 2.0 * 5.0 + 3.0 * 6.0)
+            / ((1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0).sqrt()
+                * (4.0 * 4.0 + 5.0 * 5.0 + 6.0 * 6.0).sqrt());
         assert!((cosine - expected).abs() < 1e-6);
     }
-    
+
     #[test]
     fn test_batch_processing() {
         let v1 = Vector::new(vec![1.0, 2.0, 3.0]);
@@ -307,10 +292,10 @@ mod tests {
             Vector::new(vec![4.0, 5.0, 6.0]),
             Vector::new(vec![7.0, 8.0, 9.0]),
         ];
-        
+
         let distances = v1.batch_euclidean_distance(&others);
         assert_eq!(distances.len(), 2);
-        
+
         let similarities = v1.batch_cosine_similarity(&others);
         assert_eq!(similarities.len(), 2);
     }

--- a/src/darwin/exploration.rs
+++ b/src/darwin/exploration.rs
@@ -1,25 +1,25 @@
-use std::sync::Arc;
-use anyhow::{Result, anyhow};
-use tracing::{info, warn, error, debug};
-use uuid::Uuid;
-use tokio::sync::RwLock;
+use anyhow::{anyhow, Result};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
 
-use crate::darwin::self_improvement::Modification;
 use crate::core::metrics::MetricsCollector;
+use crate::darwin::self_improvement::Modification;
 
 /// Strategy for exploring potential system improvements
 #[derive(Debug, Clone)]
 pub struct ExplorationStrategy {
     /// Metrics collector
     metrics: Arc<MetricsCollector>,
-    
+
     /// Archive of previously explored solutions
     archive: RwLock<HashMap<String, ArchiveEntry>>,
-    
+
     /// Current exploration parameters
     parameters: RwLock<ExplorationParameters>,
-    
+
     /// Novelty archive for quality-diversity
     novelty_archive: RwLock<Vec<NoveltyPoint>>,
 }
@@ -28,13 +28,13 @@ pub struct ExplorationStrategy {
 struct ArchiveEntry {
     /// The modification
     modification: Modification,
-    
+
     /// Performance metrics
     metrics: HashMap<String, f32>,
-    
+
     /// Feature descriptors for quality-diversity
     features: HashMap<String, f32>,
-    
+
     /// When this entry was added
     added_at: chrono::DateTime<chrono::Utc>,
 }
@@ -43,19 +43,19 @@ struct ArchiveEntry {
 struct ExplorationParameters {
     /// Mutation rate
     mutation_rate: f32,
-    
+
     /// Crossover rate
     crossover_rate: f32,
-    
+
     /// Novelty threshold
     novelty_threshold: f32,
-    
+
     /// Maximum archive size
     max_archive_size: usize,
-    
+
     /// Number of parents for tournament selection
     tournament_size: usize,
-    
+
     /// Probability of selecting a random direction
     exploration_rate: f32,
 }
@@ -65,13 +65,13 @@ struct ExplorationParameters {
 struct NoveltyPoint {
     /// ID of the solution
     id: Uuid,
-    
+
     /// Feature vector describing the solution
     features: HashMap<String, f32>,
-    
+
     /// Performance score
     score: f32,
-    
+
     /// When this point was added
     added_at: chrono::DateTime<chrono::Utc>,
 }
@@ -92,49 +92,54 @@ impl ExplorationStrategy {
             novelty_archive: RwLock::new(Vec::new()),
         }
     }
-    
+
     /// Generate new modification proposals
     pub async fn generate_proposals(&self) -> Result<Vec<Modification>> {
         let mut proposals = Vec::new();
-        
+
         // Get current archive
         let archive = self.archive.read().await;
         let params = self.parameters.read().await;
-        
+
         // If archive is empty, generate some initial proposals
         if archive.is_empty() {
             proposals.extend(self.generate_initial_proposals().await?);
         } else {
             // Generate proposals through various strategies
-            
+
             // 1. Mutation of existing solutions
             let mutation_count = (archive.len() as f32 * params.mutation_rate).ceil() as usize;
             proposals.extend(self.generate_mutations(&archive, mutation_count).await?);
-            
+
             // 2. Crossover between existing solutions
             let crossover_count = (archive.len() as f32 * params.crossover_rate).ceil() as usize;
             proposals.extend(self.generate_crossovers(&archive, crossover_count).await?);
-            
+
             // 3. Novelty search for unexplored areas
             proposals.extend(self.generate_novelty_search(&archive).await?);
         }
-        
+
         // Update metrics
-        self.metrics.increment_counter("darwin.exploration.proposals_generated", proposals.len() as u64).await;
-        
+        self.metrics
+            .increment_counter(
+                "darwin.exploration.proposals_generated",
+                proposals.len() as u64,
+            )
+            .await;
+
         info!("Generated {} new modification proposals", proposals.len());
-        
+
         Ok(proposals)
     }
-    
+
     /// Generate initial proposals when archive is empty
     async fn generate_initial_proposals(&self) -> Result<Vec<Modification>> {
         // In a real implementation, this would generate initial proposals
         // based on system analysis or predefined templates
-        
+
         // For now, we'll create a simple example proposal
         let mut proposals = Vec::new();
-        
+
         let proposal = Modification {
             id: Uuid::new_v4(),
             name: "Initial optimization".to_string(),
@@ -144,12 +149,12 @@ impl ExplorationStrategy {
             created_at: chrono::Utc::now(),
             status: crate::darwin::self_improvement::ModificationStatus::Proposed,
         };
-        
+
         proposals.push(proposal);
-        
+
         Ok(proposals)
     }
-    
+
     /// Generate mutations of existing solutions
     async fn generate_mutations(
         &self,
@@ -158,30 +163,31 @@ impl ExplorationStrategy {
     ) -> Result<Vec<Modification>> {
         let mut proposals = Vec::new();
         let mut rng = rand::thread_rng();
-        
+
         // Select random entries to mutate
         let entries: Vec<&ArchiveEntry> = archive.values().collect();
-        
+
         for _ in 0..count {
             if let Some(entry) = entries.choose(&mut rng) {
                 let mut proposal = entry.modification.clone();
-                
+
                 // Update fields for the new proposal
                 proposal.id = Uuid::new_v4();
                 proposal.name = format!("Mutation of {}", entry.modification.name);
-                proposal.description = format!("Mutated version of {}", entry.modification.description);
+                proposal.description =
+                    format!("Mutated version of {}", entry.modification.description);
                 proposal.created_at = chrono::Utc::now();
                 proposal.status = crate::darwin::self_improvement::ModificationStatus::Proposed;
-                
+
                 // In a real implementation, we would actually mutate the code changes
-                
+
                 proposals.push(proposal);
             }
         }
-        
+
         Ok(proposals)
     }
-    
+
     /// Generate crossovers between existing solutions
     async fn generate_crossovers(
         &self,
@@ -190,34 +196,37 @@ impl ExplorationStrategy {
     ) -> Result<Vec<Modification>> {
         let mut proposals = Vec::new();
         let mut rng = rand::thread_rng();
-        
+
         // Select random pairs of entries to crossover
         let entries: Vec<&ArchiveEntry> = archive.values().collect();
-        
+
         for _ in 0..count {
             if entries.len() < 2 {
                 break;
             }
-            
+
             let parent1 = entries.choose(&mut rng).unwrap();
             let parent2 = entries.choose(&mut rng).unwrap();
-            
+
             let proposal = Modification {
                 id: Uuid::new_v4(),
-                name: format!("Crossover of {} and {}", parent1.modification.name, parent2.modification.name),
+                name: format!(
+                    "Crossover of {} and {}",
+                    parent1.modification.name, parent2.modification.name
+                ),
                 description: format!("Combined features from multiple parent modifications"),
                 code_changes: Vec::new(), // Would contain actual code changes from crossover
                 validation_metrics: HashMap::new(),
                 created_at: chrono::Utc::now(),
                 status: crate::darwin::self_improvement::ModificationStatus::Proposed,
             };
-            
+
             proposals.push(proposal);
         }
-        
+
         Ok(proposals)
     }
-    
+
     /// Generate proposals using novelty search
     async fn generate_novelty_search(
         &self,
@@ -225,10 +234,10 @@ impl ExplorationStrategy {
     ) -> Result<Vec<Modification>> {
         // In a real implementation, this would use novelty search to explore
         // underrepresented areas of the solution space
-        
+
         // Get the novelty archive
         let novelty_archive = self.novelty_archive.read().await;
-        
+
         // If the novelty archive is empty, just return a simple proposal
         if novelty_archive.is_empty() {
             let proposal = Modification {
@@ -240,30 +249,31 @@ impl ExplorationStrategy {
                 created_at: chrono::Utc::now(),
                 status: crate::darwin::self_improvement::ModificationStatus::Proposed,
             };
-            
+
             return Ok(vec![proposal]);
         }
-        
+
         // Find sparse areas in the feature space
         // For now, this is a simplified implementation
-        let feature_keys: HashSet<String> = novelty_archive.iter()
+        let feature_keys: HashSet<String> = novelty_archive
+            .iter()
             .flat_map(|point| point.features.keys().cloned())
             .collect();
-            
+
         let mut feature_means: HashMap<String, f32> = HashMap::new();
         let mut feature_counts: HashMap<String, usize> = HashMap::new();
-        
+
         // Calculate mean for each feature
         for point in novelty_archive.iter() {
             for (key, value) in &point.features {
                 let count = feature_counts.entry(key.clone()).or_insert(0);
                 *count += 1;
-                
+
                 let sum = feature_means.entry(key.clone()).or_insert(0.0);
                 *sum += value;
             }
         }
-        
+
         // Finalize means
         for (key, sum) in &mut feature_means {
             if let Some(count) = feature_counts.get(key) {
@@ -272,7 +282,7 @@ impl ExplorationStrategy {
                 }
             }
         }
-        
+
         // Generate a proposal that's different from the mean
         let mut target_features = HashMap::new();
         for key in feature_keys {
@@ -281,11 +291,11 @@ impl ExplorationStrategy {
                 let mut rng = rand::thread_rng();
                 let direction = if rng.gen::<f32>() > 0.5 { 1.0 } else { -1.0 };
                 let magnitude = rng.gen::<f32>() * 0.5 + 0.5; // 0.5 to 1.0
-                
+
                 target_features.insert(key, mean + direction * magnitude);
             }
         }
-        
+
         // Create a proposal aiming for these target features
         let proposal = Modification {
             id: Uuid::new_v4(),
@@ -296,34 +306,38 @@ impl ExplorationStrategy {
             created_at: chrono::Utc::now(),
             status: crate::darwin::self_improvement::ModificationStatus::Proposed,
         };
-        
+
         Ok(vec![proposal])
     }
-    
+
     /// Tournament selection for choosing parents
-    async fn tournament_selection(&self, archive: &HashMap<String, ArchiveEntry>) -> Option<ArchiveEntry> {
+    async fn tournament_selection(
+        &self,
+        archive: &HashMap<String, ArchiveEntry>,
+    ) -> Option<ArchiveEntry> {
         let params = self.parameters.read().await;
         let mut rng = rand::thread_rng();
-        
+
         // If archive is too small, just return a random entry
         if archive.len() <= 1 {
             return archive.values().next().cloned();
         }
-        
+
         let entries: Vec<&ArchiveEntry> = archive.values().collect();
-        
+
         // Select tournament_size random entries
         let tournament_size = std::cmp::min(params.tournament_size, entries.len());
         let mut tournament = Vec::with_capacity(tournament_size);
-        
+
         for _ in 0..tournament_size {
             if let Some(entry) = entries.choose(&mut rng) {
                 tournament.push(*entry);
             }
         }
-        
+
         // Find the best entry in the tournament
-        tournament.into_iter()
+        tournament
+            .into_iter()
             .max_by(|a, b| {
                 // Compare based on sum of metrics (higher is better)
                 let a_score: f32 = a.metrics.values().sum();
@@ -332,7 +346,7 @@ impl ExplorationStrategy {
             })
             .cloned()
     }
-    
+
     /// Add a validated modification to the archive
     pub async fn add_to_archive(
         &self,
@@ -341,55 +355,57 @@ impl ExplorationStrategy {
     ) -> Result<()> {
         let mut archive = self.archive.write().await;
         let params = self.parameters.read().await;
-        
+
         // Generate feature descriptors for quality-diversity
         let features = self.extract_features(&modification, &metrics);
-        
+
+        // Calculate novelty info before moving values
+        let score = metrics.values().sum();
+        let novelty_point = NoveltyPoint {
+            id: modification.id,
+            features: features.clone(),
+            score,
+            added_at: chrono::Utc::now(),
+        };
+
         // Create archive entry
         let entry = ArchiveEntry {
             modification,
             metrics,
-            features: features.clone(),
+            features,
             added_at: chrono::Utc::now(),
         };
-        
+
         // Add to archive
         let key = entry.modification.id.to_string();
         archive.insert(key, entry);
-        
-        // Add to novelty archive
-        let score = metrics.values().sum();
-        let novelty_point = NoveltyPoint {
-            id: modification.id,
-            features,
-            score,
-            added_at: chrono::Utc::now(),
-        };
-        
+
         {
             let mut novelty_archive = self.novelty_archive.write().await;
             novelty_archive.push(novelty_point);
-            
+
             // Keep novelty archive sorted by score (descending)
             novelty_archive.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
-            
+
             // Trim novelty archive if needed
             if novelty_archive.len() > params.max_archive_size {
                 novelty_archive.truncate(params.max_archive_size);
             }
         }
-        
+
         // Trim archive if needed
         if archive.len() > params.max_archive_size {
             self.trim_archive(&mut archive).await?;
         }
-        
+
         // Update metrics
-        self.metrics.set_gauge("darwin.exploration.archive_size", archive.len() as u64).await;
-        
+        self.metrics
+            .set_gauge("darwin.exploration.archive_size", archive.len() as u64)
+            .await;
+
         Ok(())
     }
-    
+
     /// Extract feature descriptors for quality-diversity
     fn extract_features(
         &self,
@@ -397,139 +413,138 @@ impl ExplorationStrategy {
         metrics: &HashMap<String, f32>,
     ) -> HashMap<String, f32> {
         let mut features = HashMap::new();
-        
+
         // In a real implementation, this would extract meaningful features
         // that describe the solution in a way that promotes diversity
-        
+
         // For now, we'll use some example features
-        features.insert("code_size".to_string(), modification.code_changes.len() as f32);
-        
+        features.insert(
+            "code_size".to_string(),
+            modification.code_changes.len() as f32,
+        );
+
         if let Some(latency) = metrics.get("performance.vector_search_latency_ms") {
             features.insert("latency".to_string(), *latency);
         }
-        
+
         if let Some(throughput) = metrics.get("performance.throughput_qps") {
             features.insert("throughput".to_string(), *throughput);
         }
-        
+
         features
     }
-    
+
     /// Calculate novelty score for a solution
     async fn calculate_novelty_score(&self, features: &HashMap<String, f32>) -> f32 {
         let novelty_archive = self.novelty_archive.read().await;
-        
+
         if novelty_archive.is_empty() {
             return 1.0; // Maximum novelty if archive is empty
         }
-        
+
         // Calculate average distance to k-nearest neighbors
         let k = std::cmp::min(15, novelty_archive.len());
-        
+
         let mut distances = Vec::with_capacity(novelty_archive.len());
-        
+
         for point in novelty_archive.iter() {
             let distance = self.feature_distance(features, &point.features);
             distances.push(distance);
         }
-        
+
         // Sort distances and take the k smallest
         distances.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        
-        let avg_distance = distances.iter()
-            .take(k)
-            .sum::<f32>() / k as f32;
-            
+
+        let avg_distance = distances.iter().take(k).sum::<f32>() / k as f32;
+
         avg_distance
     }
-    
+
     /// Calculate distance between feature vectors
     fn feature_distance(&self, a: &HashMap<String, f32>, b: &HashMap<String, f32>) -> f32 {
         let mut sum_squared_diff = 0.0;
         let mut feature_count = 0;
-        
+
         // Get all unique keys
         let all_keys: HashSet<_> = a.keys().chain(b.keys()).collect();
-        
+
         for key in all_keys {
             let a_val = a.get(key).copied().unwrap_or(0.0);
             let b_val = b.get(key).copied().unwrap_or(0.0);
-            
+
             let diff = a_val - b_val;
             sum_squared_diff += diff * diff;
             feature_count += 1;
         }
-        
+
         if feature_count == 0 {
             return 0.0;
         }
-        
+
         (sum_squared_diff / feature_count as f32).sqrt()
     }
-    
+
     /// Trim the archive to maintain diversity
-    async fn trim_archive(
-        &self,
-        archive: &mut HashMap<String, ArchiveEntry>,
-    ) -> Result<()> {
+    async fn trim_archive(&self, archive: &mut HashMap<String, ArchiveEntry>) -> Result<()> {
         // In a real implementation, this would use quality-diversity
         // algorithms to maintain a diverse set of high-quality solutions
-        
+
         // For now, we'll just keep the newest entries
         let mut entries: Vec<(String, ArchiveEntry)> = archive.drain().collect();
         entries.sort_by(|a, b| b.1.added_at.cmp(&a.1.added_at));
-        
+
         let params = self.parameters.read().await;
         entries.truncate(params.max_archive_size);
-        
+
         for (key, entry) in entries {
             archive.insert(key, entry);
         }
-        
+
         Ok(())
     }
-    
+
     /// Update exploration parameters
-    pub async fn update_parameters(&self, 
+    pub async fn update_parameters(
+        &self,
         mutation_rate: Option<f32>,
         crossover_rate: Option<f32>,
         novelty_threshold: Option<f32>,
         exploration_rate: Option<f32>,
     ) -> Result<()> {
         let mut params = self.parameters.write().await;
-        
+
         if let Some(rate) = mutation_rate {
             params.mutation_rate = rate.max(0.0).min(1.0);
         }
-        
+
         if let Some(rate) = crossover_rate {
             params.crossover_rate = rate.max(0.0).min(1.0);
         }
-        
+
         if let Some(threshold) = novelty_threshold {
             params.novelty_threshold = threshold.max(0.0);
         }
-        
+
         if let Some(rate) = exploration_rate {
             params.exploration_rate = rate.max(0.0).min(1.0);
         }
-        
+
         info!("Updated exploration parameters: mutation_rate={:.2}, crossover_rate={:.2}, novelty_threshold={:.2}, exploration_rate={:.2}",
               params.mutation_rate, params.crossover_rate, params.novelty_threshold, params.exploration_rate);
-        
+
         Ok(())
     }
-    
+
     /// Get the current exploration parameters
     pub async fn get_parameters(&self) -> ExplorationParameters {
         self.parameters.read().await.clone()
     }
-    
+
     /// Get statistics about the exploration archive
     pub async fn get_archive_stats(&self) -> ArchiveStats {
         let archive = self.archive.read().await;
         let novelty_archive = self.novelty_archive.read().await;
-        
+
         ArchiveStats {
             total_entries: archive.len(),
             novelty_entries: novelty_archive.len(),
@@ -537,60 +552,63 @@ impl ExplorationStrategy {
             top_scores: self.get_top_scores(5).await,
         }
     }
-    
+
     /// Calculate feature coverage (how much of the feature space is explored)
     async fn calculate_feature_coverage(&self) -> f32 {
         // This is a placeholder - a real implementation would calculate
         // a more sophisticated coverage metric
         let novelty_archive = self.novelty_archive.read().await;
-        
+
         if novelty_archive.is_empty() {
             return 0.0;
         }
-        
+
         // Count unique features
-        let feature_keys: HashSet<_> = novelty_archive.iter()
+        let feature_keys: HashSet<_> = novelty_archive
+            .iter()
             .flat_map(|point| point.features.keys().cloned())
             .collect();
-            
+
         // Simple coverage metric based on number of features and points
         let feature_count = feature_keys.len();
         let point_count = novelty_archive.len();
-        
+
         if feature_count == 0 {
             return 0.0;
         }
-        
+
         // Calculate dispersion of points for each feature
         let mut total_dispersion = 0.0;
-        
+
         for key in feature_keys {
-            let values: Vec<f32> = novelty_archive.iter()
+            let values: Vec<f32> = novelty_archive
+                .iter()
                 .filter_map(|point| point.features.get(&key).copied())
                 .collect();
-                
+
             if values.is_empty() {
                 continue;
             }
-            
+
             // Calculate min and max
             let min = values.iter().fold(f32::INFINITY, |a, &b| a.min(b));
             let max = values.iter().fold(f32::NEG_INFINITY, |a, &b| a.max(b));
-            
+
             if min.is_finite() && max.is_finite() && max > min {
                 total_dispersion += (max - min);
             }
         }
-        
+
         // Normalize by feature count
         total_dispersion / feature_count as f32
     }
-    
+
     /// Get top scoring solutions
     async fn get_top_scores(&self, count: usize) -> Vec<(Uuid, f32)> {
         let novelty_archive = self.novelty_archive.read().await;
-        
-        novelty_archive.iter()
+
+        novelty_archive
+            .iter()
             .take(count)
             .map(|point| (point.id, point.score))
             .collect()

--- a/src/darwin/ritual.rs
+++ b/src/darwin/ritual.rs
@@ -1,10 +1,10 @@
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
-use anyhow::{Result, anyhow};
-use tracing::{info, warn, error, debug};
-use chrono::{DateTime, Utc};
 
 use crate::core::metrics::MetricsCollector;
 use crate::darwin::self_improvement::Modification;
@@ -59,12 +59,17 @@ impl RitualManager {
             active_rituals: RwLock::new(HashSet::new()),
         }
     }
-    
+
     /// Create a new ritual learning cycle
-    pub async fn create_ritual(&self, name: &str, description: &str, stages: Vec<RitualStage>) -> Result<Uuid> {
+    pub async fn create_ritual(
+        &self,
+        name: &str,
+        description: &str,
+        stages: Vec<RitualStage>,
+    ) -> Result<Uuid> {
         let id = Uuid::new_v4();
         let now = Utc::now();
-        
+
         let ritual = Ritual {
             id,
             name: name.to_string(),
@@ -75,140 +80,188 @@ impl RitualManager {
             updated_at: now,
             completed_at: None,
         };
-        
+
         // Store the ritual
         self.rituals.write().await.insert(id, ritual);
         self.active_rituals.write().await.insert(id);
-        
+
         // Update metrics
-        self.metrics.increment_counter("darwin.rituals.created", 1).await;
-        
+        self.metrics
+            .increment_counter("darwin.rituals.created", 1)
+            .await;
+
         info!("Created new ritual '{}' with ID: {}", name, id);
-        
+
         Ok(id)
     }
-    
+
     /// Get a ritual by ID
     pub async fn get_ritual(&self, id: Uuid) -> Result<Ritual> {
         let rituals = self.rituals.read().await;
-        
-        rituals.get(&id)
+
+        rituals
+            .get(&id)
             .cloned()
             .ok_or_else(|| anyhow!("Ritual with ID {} not found", id))
     }
-    
+
     /// Start a ritual stage
     pub async fn start_stage(&self, ritual_id: Uuid, stage_name: &str) -> Result<()> {
         let mut rituals = self.rituals.write().await;
-        
-        let ritual = rituals.get_mut(&ritual_id)
+
+        let ritual = rituals
+            .get_mut(&ritual_id)
             .ok_or_else(|| anyhow!("Ritual with ID {} not found", ritual_id))?;
-            
+
         // Find the stage
-        let stage = ritual.stages.iter_mut()
-            .find(|s| s.name == stage_name)
+        let stage_index = ritual
+            .stages
+            .iter()
+            .position(|s| s.name == stage_name)
             .ok_or_else(|| anyhow!("Stage {} not found in ritual {}", stage_name, ritual_id))?;
-            
-        // Check dependencies
-        for dep_name in &stage.depends_on {
-            let dep_stage = ritual.stages.iter()
-                .find(|s| &s.name == dep_name)
-                .ok_or_else(|| anyhow!("Dependency stage {} not found", dep_name))?;
-                
-            if dep_stage.status != RitualStageStatus::Completed {
-                return Err(anyhow!("Dependency stage {} is not completed", dep_name));
+
+        // Check dependencies using an immutable borrow first
+        {
+            let stage = &ritual.stages[stage_index];
+            for dep_name in &stage.depends_on {
+                let dep_stage = ritual
+                    .stages
+                    .iter()
+                    .find(|s| &s.name == dep_name)
+                    .ok_or_else(|| anyhow!("Dependency stage {} not found", dep_name))?;
+
+                if dep_stage.status != RitualStageStatus::Completed {
+                    return Err(anyhow!("Dependency stage {} is not completed", dep_name));
+                }
             }
         }
-        
-        // Update stage status
-        stage.status = RitualStageStatus::InProgress;
-        stage.started_at = Some(Utc::now());
+
+        // Mutably borrow the stage to update its status
+        {
+            let stage = &mut ritual.stages[stage_index];
+            stage.status = RitualStageStatus::InProgress;
+            stage.started_at = Some(Utc::now());
+        }
         ritual.updated_at = Utc::now();
-        
+
         info!("Started stage '{}' of ritual '{}'", stage_name, ritual.name);
-        
+
         Ok(())
     }
-    
+
     /// Complete a ritual stage
-    pub async fn complete_stage(&self, ritual_id: Uuid, stage_name: &str, artifacts: Vec<String>) -> Result<()> {
+    pub async fn complete_stage(
+        &self,
+        ritual_id: Uuid,
+        stage_name: &str,
+        artifacts: Vec<String>,
+    ) -> Result<()> {
         let mut rituals = self.rituals.write().await;
-        
-        let ritual = rituals.get_mut(&ritual_id)
+
+        let ritual = rituals
+            .get_mut(&ritual_id)
             .ok_or_else(|| anyhow!("Ritual with ID {} not found", ritual_id))?;
-            
+
         // Find the stage
-        let stage = ritual.stages.iter_mut()
-            .find(|s| s.name == stage_name)
+        let stage_index = ritual
+            .stages
+            .iter()
+            .position(|s| s.name == stage_name)
             .ok_or_else(|| anyhow!("Stage {} not found in ritual {}", stage_name, ritual_id))?;
-            
-        // Update stage status
-        stage.status = RitualStageStatus::Completed;
-        stage.completed_at = Some(Utc::now());
-        stage.artifacts = artifacts;
+
+        {
+            let stage = &mut ritual.stages[stage_index];
+            stage.status = RitualStageStatus::Completed;
+            stage.completed_at = Some(Utc::now());
+            stage.artifacts = artifacts;
+        }
         ritual.updated_at = Utc::now();
-        
-        // Check if all stages are completed
-        let all_completed = ritual.stages.iter().all(|s| s.status == RitualStageStatus::Completed);
-        
+
+        let all_completed = ritual
+            .stages
+            .iter()
+            .all(|s| s.status == RitualStageStatus::Completed);
+
         if all_completed {
             ritual.completed_at = Some(Utc::now());
             self.active_rituals.write().await.remove(&ritual_id);
             info!("Completed ritual '{}'", ritual.name);
-            
+
             // Update metrics
-            self.metrics.increment_counter("darwin.rituals.completed", 1).await;
+            self.metrics
+                .increment_counter("darwin.rituals.completed", 1)
+                .await;
         }
-        
-        info!("Completed stage '{}' of ritual '{}'", stage_name, ritual.name);
-        
+
+        info!(
+            "Completed stage '{}' of ritual '{}'",
+            stage_name, ritual.name
+        );
+
         Ok(())
     }
-    
+
     /// Link a modification to a ritual
-    pub async fn link_modification(&self, ritual_id: Uuid, modification: &Modification) -> Result<()> {
+    pub async fn link_modification(
+        &self,
+        ritual_id: Uuid,
+        modification: &Modification,
+    ) -> Result<()> {
         let mut rituals = self.rituals.write().await;
-        
-        let ritual = rituals.get_mut(&ritual_id)
+
+        let ritual = rituals
+            .get_mut(&ritual_id)
             .ok_or_else(|| anyhow!("Ritual with ID {} not found", ritual_id))?;
-            
+
         // Add the modification ID as an artifact to the current active stage
-        if let Some(stage) = ritual.stages.iter_mut().find(|s| s.status == RitualStageStatus::InProgress) {
+        if let Some(stage) = ritual
+            .stages
+            .iter_mut()
+            .find(|s| s.status == RitualStageStatus::InProgress)
+        {
             stage.artifacts.push(modification.id.to_string());
-            info!("Linked modification {} to stage '{}' of ritual '{}'", 
-                  modification.id, stage.name, ritual.name);
+            info!(
+                "Linked modification {} to stage '{}' of ritual '{}'",
+                modification.id, stage.name, ritual.name
+            );
         }
-        
+
         Ok(())
     }
-    
+
     /// Get active rituals
     pub async fn get_active_rituals(&self) -> Result<Vec<Ritual>> {
         let rituals = self.rituals.read().await;
         let active_ids = self.active_rituals.read().await;
-        
-        let active_rituals = active_ids.iter()
+
+        let active_rituals = active_ids
+            .iter()
             .filter_map(|id| rituals.get(id))
             .cloned()
             .collect();
-            
+
         Ok(active_rituals)
     }
-    
+
     /// Add metrics to a ritual
-    pub async fn add_ritual_metrics(&self, ritual_id: Uuid, metrics: HashMap<String, f32>) -> Result<()> {
+    pub async fn add_ritual_metrics(
+        &self,
+        ritual_id: Uuid,
+        metrics: HashMap<String, f32>,
+    ) -> Result<()> {
         let mut rituals = self.rituals.write().await;
-        
-        let ritual = rituals.get_mut(&ritual_id)
+
+        let ritual = rituals
+            .get_mut(&ritual_id)
             .ok_or_else(|| anyhow!("Ritual with ID {} not found", ritual_id))?;
-            
+
         // Merge metrics
         for (key, value) in metrics {
             ritual.metrics.insert(key, value);
         }
-        
+
         ritual.updated_at = Utc::now();
-        
+
         Ok(())
     }
 }

--- a/src/darwin/validation.rs
+++ b/src/darwin/validation.rs
@@ -1,27 +1,27 @@
+use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 use std::sync::Arc;
-use anyhow::{Result, anyhow};
-use tracing::{info, warn, error, debug};
 use tokio::sync::RwLock;
+use tracing::{debug, error, info, warn};
 
-use crate::darwin::self_improvement::Modification;
 use crate::core::metrics::MetricsCollector;
+use crate::darwin::self_improvement::Modification;
 
 /// Validation pipeline for testing proposed modifications
 #[derive(Debug, Clone)]
 pub struct ValidationPipeline {
     /// Metrics collector
     metrics: Arc<MetricsCollector>,
-    
+
     /// Validation stages
     stages: Vec<Box<dyn ValidationStage>>,
-    
+
     /// Validation thresholds
     thresholds: HashMap<String, f32>,
-    
+
     /// Dynamic validation rules
     dynamic_rules: RwLock<Vec<DynamicValidationRule>>,
-    
+
     /// Validation history for learning
     validation_history: RwLock<Vec<ValidationResult>>,
 }
@@ -30,7 +30,7 @@ pub struct ValidationPipeline {
 pub trait ValidationStage: Send + Sync {
     /// Get the name of this validation stage
     fn name(&self) -> &str;
-    
+
     /// Run validation and return metrics
     fn validate(&self, modification: &Modification) -> Result<HashMap<String, f32>>;
 }
@@ -40,16 +40,16 @@ pub trait ValidationStage: Send + Sync {
 struct DynamicValidationRule {
     /// Name of this rule
     name: String,
-    
+
     /// Metrics this rule applies to
     metrics: Vec<String>,
-    
+
     /// Threshold function (returns pass/fail)
     threshold_fn: fn(&HashMap<String, f32>) -> bool,
-    
+
     /// How often this rule has been correct
     success_rate: f32,
-    
+
     /// When this rule was created or last updated
     updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -59,16 +59,16 @@ struct DynamicValidationRule {
 struct ValidationResult {
     /// The modification that was validated
     modification_id: uuid::Uuid,
-    
+
     /// Metrics from validation
     metrics: HashMap<String, f32>,
-    
+
     /// Whether validation passed
     passed: bool,
-    
+
     /// Whether this decision was correct (determined later)
     was_correct: Option<bool>,
-    
+
     /// When validation occurred
     timestamp: chrono::DateTime<chrono::Utc>,
 }
@@ -83,79 +83,85 @@ impl ValidationPipeline {
             validation_history: RwLock::new(Vec::new()),
         }
     }
-    
+
     /// Add a validation stage
     pub fn add_stage<T: ValidationStage + 'static>(&mut self, stage: T) {
         self.stages.push(Box::new(stage));
     }
-    
+
     /// Set a validation threshold
     pub fn set_threshold(&mut self, metric: &str, threshold: f32) {
         self.thresholds.insert(metric.to_string(), threshold);
     }
-    
+
     /// Add a dynamic validation rule
     pub async fn add_dynamic_rule(&self, rule: DynamicValidationRule) {
         let mut rules = self.dynamic_rules.write().await;
         rules.push(rule);
     }
-    
+
     /// Run all validation stages
     pub async fn validate(&self, modification: &Modification) -> Result<HashMap<String, f32>> {
         let mut all_metrics = HashMap::new();
-        
+
         for stage in &self.stages {
             debug!("Running validation stage: {}", stage.name());
-            
+
             match stage.validate(modification) {
                 Ok(metrics) => {
                     // Add metrics from this stage
                     for (key, value) in metrics {
                         all_metrics.insert(format!("{}.{}", stage.name(), key), value);
                     }
-                },
+                }
                 Err(e) => {
                     error!("Validation stage {} failed: {}", stage.name(), e);
                     return Err(anyhow!("Validation stage {} failed: {}", stage.name(), e));
                 }
             }
         }
-        
+
         // Update metrics
         for (key, value) in &all_metrics {
-            self.metrics.set_gauge(&format!("darwin.validation.{}", key), *value as u64).await;
+            self.metrics
+                .set_gauge(&format!("darwin.validation.{}", key), *value as u64)
+                .await;
         }
-        
+
         // Store validation result in history
         let passed = self.is_valid(&all_metrics);
         let result = ValidationResult {
             modification_id: modification.id,
             metrics: all_metrics.clone(),
             passed,
-            was_correct: None,  // To be determined later
+            was_correct: None, // To be determined later
             timestamp: chrono::Utc::now(),
         };
-        
+
         let mut history = self.validation_history.write().await;
         history.push(result);
-        
+
         // Trim history if it gets too large
         const MAX_HISTORY: usize = 1000;
         if history.len() > MAX_HISTORY {
             history.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-            history.drain(0..history.len() - MAX_HISTORY);
+            let len = history.len();
+            history.drain(0..len - MAX_HISTORY);
         }
-        
+
         Ok(all_metrics)
     }
-    
+
     /// Check if validation metrics pass all thresholds
     pub fn is_valid(&self, metrics: &HashMap<String, f32>) -> bool {
         // Check static thresholds
         for (metric, threshold) in &self.thresholds {
             if let Some(value) = metrics.get(metric) {
                 if *value < *threshold {
-                    warn!("Validation failed for metric {}: {} < {}", metric, value, threshold);
+                    warn!(
+                        "Validation failed for metric {}: {} < {}",
+                        metric, value, threshold
+                    );
                     return false;
                 }
             } else {
@@ -163,89 +169,113 @@ impl ValidationPipeline {
                 return false;
             }
         }
-        
+
         // The dynamic rules would be checked here in a more complete implementation
-        
+
         true
     }
-    
+
     /// Update validation rule based on past performance
     pub async fn update_rules_from_history(&self) -> Result<usize> {
         let history = self.validation_history.read().await;
         let mut rules = self.dynamic_rules.write().await;
-        
+
         let mut updated_count = 0;
-        
+
         // Only use history items where we know if the decision was correct
-        let valid_history: Vec<_> = history.iter()
+        let valid_history: Vec<_> = history
+            .iter()
             .filter(|result| result.was_correct.is_some())
             .collect();
-        
+
         if valid_history.is_empty() {
             return Ok(0);
         }
-        
+
         // Update each rule based on its performance
         for rule in rules.iter_mut() {
             // Find history items where this rule's metrics were present
-            let relevant_history: Vec<_> = valid_history.iter()
+            let relevant_history: Vec<_> = valid_history
+                .iter()
                 .filter(|result| rule.metrics.iter().all(|m| result.metrics.contains_key(m)))
                 .collect();
-            
+
             if relevant_history.is_empty() {
                 continue;
             }
-            
+
             // Calculate success rate
-            let correct_count = relevant_history.iter()
+            let correct_count = relevant_history
+                .iter()
                 .filter(|result| {
                     let rule_decision = (rule.threshold_fn)(&result.metrics);
                     rule_decision == result.was_correct.unwrap()
                 })
                 .count();
-            
+
             rule.success_rate = correct_count as f32 / relevant_history.len() as f32;
             rule.updated_at = chrono::Utc::now();
             updated_count += 1;
-            
-            info!("Updated rule '{}' success rate to {:.2}", rule.name, rule.success_rate);
+
+            info!(
+                "Updated rule '{}' success rate to {:.2}",
+                rule.name, rule.success_rate
+            );
         }
-        
+
         // Generate new rules based on patterns in history
         self.generate_new_rules().await?;
-        
+
         Ok(updated_count)
     }
-    
+
     /// Generate new validation rules based on observed patterns
     async fn generate_new_rules(&self) -> Result<usize> {
         // This would implement a more sophisticated rule learning algorithm
         // For now, this is a placeholder
         Ok(0)
     }
-    
+
     /// Mark a validation result as correct or incorrect
-    pub async fn feedback_on_validation(&self, modification_id: uuid::Uuid, was_correct: bool) -> Result<()> {
+    pub async fn feedback_on_validation(
+        &self,
+        modification_id: uuid::Uuid,
+        was_correct: bool,
+    ) -> Result<()> {
         let mut history = self.validation_history.write().await;
-        
-        let found = history.iter_mut()
+
+        let found = history
+            .iter_mut()
             .find(|result| result.modification_id == modification_id)
-            .ok_or_else(|| anyhow!("Validation result for modification {} not found", modification_id))?;
-            
+            .ok_or_else(|| {
+                anyhow!(
+                    "Validation result for modification {} not found",
+                    modification_id
+                )
+            })?;
+
         found.was_correct = Some(was_correct);
-        
-        info!("Received feedback on validation for modification {}: correct={}", 
-              modification_id, was_correct);
-        
+
+        info!(
+            "Received feedback on validation for modification {}: correct={}",
+            modification_id, was_correct
+        );
+
         // Update metrics
-        self.metrics.increment_counter("darwin.validation.feedback_received", 1).await;
-        
+        self.metrics
+            .increment_counter("darwin.validation.feedback_received", 1)
+            .await;
+
         if was_correct {
-            self.metrics.increment_counter("darwin.validation.correct_decisions", 1).await;
+            self.metrics
+                .increment_counter("darwin.validation.correct_decisions", 1)
+                .await;
         } else {
-            self.metrics.increment_counter("darwin.validation.incorrect_decisions", 1).await;
+            self.metrics
+                .increment_counter("darwin.validation.incorrect_decisions", 1)
+                .await;
         }
-        
+
         Ok(())
     }
 }
@@ -258,14 +288,14 @@ impl ValidationStage for UnitTestStage {
     fn name(&self) -> &str {
         "unit_tests"
     }
-    
+
     fn validate(&self, _modification: &Modification) -> Result<HashMap<String, f32>> {
         // In a real implementation, this would run actual unit tests
         // For now, we'll simulate test results
         let mut metrics = HashMap::new();
         metrics.insert("pass_rate".to_string(), 0.95);
         metrics.insert("coverage".to_string(), 0.85);
-        
+
         Ok(metrics)
     }
 }
@@ -278,7 +308,7 @@ impl ValidationStage for PerformanceBenchmarkStage {
     fn name(&self) -> &str {
         "performance"
     }
-    
+
     fn validate(&self, _modification: &Modification) -> Result<HashMap<String, f32>> {
         // In a real implementation, this would run performance benchmarks
         // For now, we'll simulate benchmark results
@@ -286,7 +316,7 @@ impl ValidationStage for PerformanceBenchmarkStage {
         metrics.insert("vector_search_latency_ms".to_string(), 8.5);
         metrics.insert("crdt_merge_latency_ms".to_string(), 0.8);
         metrics.insert("throughput_qps".to_string(), 12000.0);
-        
+
         Ok(metrics)
     }
 }
@@ -299,14 +329,14 @@ impl ValidationStage for SecurityValidationStage {
     fn name(&self) -> &str {
         "security"
     }
-    
+
     fn validate(&self, _modification: &Modification) -> Result<HashMap<String, f32>> {
         // In a real implementation, this would run security checks
         // For now, we'll simulate security validation results
         let mut metrics = HashMap::new();
         metrics.insert("vulnerability_score".to_string(), 0.1); // Lower is better
         metrics.insert("compliance_score".to_string(), 0.98);
-        
+
         Ok(metrics)
     }
 }
@@ -323,7 +353,7 @@ impl MultiLanguageValidationStage {
             language_handlers: HashMap::new(),
         }
     }
-    
+
     pub fn add_language_handler(&mut self, language: &str, handler: Box<dyn ValidationStage>) {
         self.language_handlers.insert(language.to_string(), handler);
     }
@@ -333,10 +363,10 @@ impl ValidationStage for MultiLanguageValidationStage {
     fn name(&self) -> &str {
         "multi_language"
     }
-    
+
     fn validate(&self, modification: &Modification) -> Result<HashMap<String, f32>> {
         let mut all_metrics = HashMap::new();
-        
+
         // Determine the language for each file in the modification
         for change in &modification.code_changes {
             let extension = change.file_path.split('.').last().unwrap_or("");
@@ -351,7 +381,7 @@ impl ValidationStage for MultiLanguageValidationStage {
                 "cpp" | "cc" | "cxx" => "cpp",
                 _ => "unknown",
             };
-            
+
             if let Some(handler) = self.language_handlers.get(language) {
                 // Run the language-specific validator
                 match handler.validate(modification) {
@@ -359,14 +389,17 @@ impl ValidationStage for MultiLanguageValidationStage {
                         for (key, value) in metrics {
                             all_metrics.insert(format!("{}.{}", language, key), value);
                         }
-                    },
+                    }
                     Err(e) => {
-                        warn!("Language-specific validation for {} failed: {}", language, e);
+                        warn!(
+                            "Language-specific validation for {} failed: {}",
+                            language, e
+                        );
                     }
                 }
             }
         }
-        
+
         Ok(all_metrics)
     }
 }

--- a/src/nerv/synchrony.rs
+++ b/src/nerv/synchrony.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tracing::{error, info, warn};
 use uuid::Uuid;
-use tracing::{info, warn, error};
 
 type VectorClock = HashMap<String, u64>;
 
@@ -23,93 +23,96 @@ impl SynchronyManager {
     pub fn new(node_id: &str) -> Self {
         let mut clock = HashMap::new();
         clock.insert(node_id.to_string(), 0);
-        
+
         let state = SynchronyState {
             node_id: node_id.to_string(),
             clock,
             last_sync: HashMap::new(),
         };
-        
+
         Self {
             state: RwLock::new(state),
             peers: RwLock::new(HashSet::new()),
         }
     }
-    
+
     pub async fn add_peer(&self, peer_id: &str) {
         self.peers.write().await.insert(peer_id.to_string());
         info!("Added peer {} to synchrony manager", peer_id);
     }
-    
+
     pub async fn remove_peer(&self, peer_id: &str) {
         self.peers.write().await.remove(peer_id);
         info!("Removed peer {} from synchrony manager", peer_id);
     }
-    
+
     pub async fn increment_local_clock(&self) -> u64 {
         let mut state = self.state.write().await;
-        let counter = state.clock.entry(state.node_id.clone()).or_insert(0);
+        let node_id = state.node_id.clone();
+        let counter = state.clock.entry(node_id).or_insert(0);
         *counter += 1;
         *counter
     }
-    
+
     pub async fn merge_remote_clock(&self, remote_node: &str, remote_clock: VectorClock) {
         let mut state = self.state.write().await;
-        
+
         // Update last sync time
-        state.last_sync.insert(remote_node.to_string(), chrono::Utc::now());
-        
+        state
+            .last_sync
+            .insert(remote_node.to_string(), chrono::Utc::now());
+
         // Merge the clocks
         for (node, &timestamp) in &remote_clock {
             let local_timestamp = state.clock.entry(node.clone()).or_insert(0);
             *local_timestamp = std::cmp::max(*local_timestamp, timestamp);
         }
-        
+
         info!("Merged clock from node {}", remote_node);
     }
-    
+
     pub async fn get_current_clock(&self) -> VectorClock {
         self.state.read().await.clock.clone()
     }
-    
+
     pub async fn is_causally_ready(&self, event_clock: &VectorClock) -> bool {
         let state = self.state.read().await;
-        
+
         for (node, &timestamp) in event_clock {
             if node == &state.node_id {
                 continue; // Skip our own node
             }
-            
+
             let local_timestamp = state.clock.get(node).copied().unwrap_or(0);
             if local_timestamp < timestamp {
                 // We haven't seen all the events this event depends on
                 return false;
             }
         }
-        
+
         true
     }
-    
+
     pub async fn get_sync_status(&self) -> HashMap<String, (chrono::DateTime<chrono::Utc>, bool)> {
         let state = self.state.read().await;
         let peers = self.peers.read().await;
-        
+
         let mut result = HashMap::new();
         let now = chrono::Utc::now();
-        
+
         // Threshold for considering a node out of sync (5 minutes)
         let threshold = chrono::Duration::minutes(5);
-        
+
         for peer in peers.iter() {
             let last_sync = state.last_sync.get(peer).copied().unwrap_or_else(|| {
                 // If we've never synced, use a very old time
                 chrono::Utc::now() - chrono::Duration::days(365)
             });
-            
+
             let is_in_sync = now - last_sync < threshold;
             result.insert(peer.clone(), (last_sync, is_in_sync));
         }
-        
+
         result
     }
 }

--- a/src/sharding/vector_index.rs
+++ b/src/sharding/vector_index.rs
@@ -1,25 +1,25 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use uuid::Uuid;
 use tracing::{debug, info, warn};
+use uuid::Uuid;
 
+use crate::core::metrics::MetricsCollector;
 use crate::core::vector::Vector;
 use crate::sharding::hilbert::HilbertCurve;
-use crate::core::metrics::MetricsCollector;
 
 /// Vector index entry that maps a vector to its ID and metadata
 #[derive(Debug, Clone)]
 pub struct VectorEntry {
     /// Unique ID for this vector
     pub id: Uuid,
-    
+
     /// The vector data
     pub vector: Vector,
-    
+
     /// Optional metadata
     pub metadata: Option<HashMap<String, String>>,
-    
+
     /// When this vector was added to the index
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
@@ -29,13 +29,13 @@ pub struct VectorEntry {
 pub struct SearchResult {
     /// ID of the found vector
     pub id: Uuid,
-    
+
     /// The vector itself
     pub vector: Vector,
-    
+
     /// Optional metadata
     pub metadata: Option<HashMap<String, String>>,
-    
+
     /// Similarity or distance score
     pub score: f32,
 }
@@ -59,7 +59,7 @@ impl DistanceMetric {
             Self::Hamming => a.hamming_distance(b) as f32,
         }
     }
-    
+
     /// Check if lower scores are better (true for distances, false for similarities)
     pub fn is_lower_better(&self) -> bool {
         match self {
@@ -74,22 +74,22 @@ impl DistanceMetric {
 pub struct VectorIndex {
     /// Name of the index
     name: String,
-    
+
     /// Mapping of vector IDs to vector entries
     vectors: RwLock<HashMap<Uuid, VectorEntry>>,
-    
+
     /// Hilbert curve used for mapping vectors to 1D space
     hilbert_curve: HilbertCurve,
-    
+
     /// Mapping of Hilbert indices to vector IDs
     hilbert_map: RwLock<HashMap<u64, Vec<Uuid>>>,
-    
+
     /// Dimensions of vectors in this index
     dimensions: usize,
-    
+
     /// Distance metric used for similarity search
     distance_metric: DistanceMetric,
-    
+
     /// Metrics collector
     metrics: Option<Arc<MetricsCollector>>,
 }
@@ -97,8 +97,8 @@ pub struct VectorIndex {
 impl VectorIndex {
     /// Create a new vector index
     pub fn new(
-        name: &str, 
-        dimensions: usize, 
+        name: &str,
+        dimensions: usize,
         distance_metric: DistanceMetric,
         metrics: Option<Arc<MetricsCollector>>,
     ) -> Self {
@@ -107,11 +107,11 @@ impl VectorIndex {
         let max_total_bits = 60; // Leave some room for safety
         let bits_per_dimension = std::cmp::min(
             10, // Maximum reasonable value
-            max_total_bits / dimensions
+            max_total_bits / dimensions,
         );
-        
+
         let hilbert_curve = HilbertCurve::new(dimensions, bits_per_dimension);
-        
+
         Self {
             name: name.to_string(),
             vectors: RwLock::new(HashMap::new()),
@@ -122,12 +122,14 @@ impl VectorIndex {
             metrics,
         }
     }
-    
+
     /// Convert a vector to a Hilbert index
     fn vector_to_hilbert_index(&self, vector: &Vector) -> u64 {
         // Normalize the vector components to fit within our bit range
         let max_value = (1 << self.hilbert_curve.bits_per_dimension) - 1;
-        let point: Vec<u64> = vector.values.iter()
+        let point: Vec<u64> = vector
+            .values
+            .iter()
             .map(|&v| {
                 // Map from [-1.0, 1.0] to [0, max_value]
                 // First clamp the value to ensure it's in range
@@ -136,12 +138,16 @@ impl VectorIndex {
                 scaled.round() as u64
             })
             .collect();
-            
+
         self.hilbert_curve.point_to_index(&point)
     }
-    
+
     /// Add a vector to the index
-    pub async fn add(&self, vector: Vector, metadata: Option<HashMap<String, String>>) -> Result<Uuid, String> {
+    pub async fn add(
+        &self,
+        vector: Vector,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Result<Uuid, String> {
         // Validate dimensions
         if vector.dimensions != self.dimensions {
             return Err(format!(
@@ -149,26 +155,26 @@ impl VectorIndex {
                 self.dimensions, vector.dimensions
             ));
         }
-        
+
         let id = Uuid::new_v4();
         let now = chrono::Utc::now();
-        
+
         let entry = VectorEntry {
             id,
             vector: vector.clone(),
             metadata,
             created_at: now,
         };
-        
+
         // Calculate Hilbert index
         let hilbert_index = self.vector_to_hilbert_index(&vector);
-        
+
         // Add to vectors map
         {
             let mut vectors = self.vectors.write().await;
             vectors.insert(id, entry);
         }
-        
+
         // Add to Hilbert map
         {
             let mut hilbert_map = self.hilbert_map.write().await;
@@ -177,18 +183,25 @@ impl VectorIndex {
                 .or_insert_with(Vec::new)
                 .push(id);
         }
-        
+
         // Update metrics
         if let Some(metrics) = &self.metrics {
-            metrics.increment_counter(&format!("vector_index.{}.vectors_added", self.name), 1).await;
-            metrics.set_gauge(&format!("vector_index.{}.vector_count", self.name), self.count().await as u64).await;
+            metrics
+                .increment_counter(&format!("vector_index.{}.vectors_added", self.name), 1)
+                .await;
+            metrics
+                .set_gauge(
+                    &format!("vector_index.{}.vector_count", self.name),
+                    self.count().await as u64,
+                )
+                .await;
         }
-        
+
         debug!("Added vector to index '{}' with ID: {}", self.name, id);
-        
+
         Ok(id)
     }
-    
+
     /// Remove a vector from the index
     pub async fn remove(&self, id: Uuid) -> Result<(), String> {
         // Get the vector to calculate its Hilbert index
@@ -199,43 +212,50 @@ impl VectorIndex {
                 None => return Err(format!("Vector with ID {} not found", id)),
             }
         };
-        
+
         let hilbert_index = self.vector_to_hilbert_index(&vector);
-        
+
         // Remove from vectors map
         {
             let mut vectors = self.vectors.write().await;
             vectors.remove(&id);
         }
-        
+
         // Remove from Hilbert map
         {
             let mut hilbert_map = self.hilbert_map.write().await;
             if let Some(ids) = hilbert_map.get_mut(&hilbert_index) {
                 ids.retain(|&x| x != id);
-                
+
                 // Remove the entire entry if there are no more vectors at this index
                 if ids.is_empty() {
                     hilbert_map.remove(&hilbert_index);
                 }
             }
         }
-        
+
         // Update metrics
         if let Some(metrics) = &self.metrics {
-            metrics.increment_counter(&format!("vector_index.{}.vectors_removed", self.name), 1).await;
-            metrics.set_gauge(&format!("vector_index.{}.vector_count", self.name), self.count().await as u64).await;
+            metrics
+                .increment_counter(&format!("vector_index.{}.vectors_removed", self.name), 1)
+                .await;
+            metrics
+                .set_gauge(
+                    &format!("vector_index.{}.vector_count", self.name),
+                    self.count().await as u64,
+                )
+                .await;
         }
-        
+
         debug!("Removed vector from index '{}' with ID: {}", self.name, id);
-        
+
         Ok(())
     }
-    
+
     /// Find nearest vectors using the index
     pub async fn search(&self, query: &Vector, limit: usize) -> Result<Vec<SearchResult>, String> {
         let start = std::time::Instant::now();
-        
+
         // Validate dimensions
         if query.dimensions != self.dimensions {
             return Err(format!(
@@ -243,41 +263,45 @@ impl VectorIndex {
                 self.dimensions, query.dimensions
             ));
         }
-        
+
         // Calculate Hilbert index of the query
         let query_hilbert_index = self.vector_to_hilbert_index(query);
-        
+
         // Get nearby indices in Hilbert space
         // This is a simplified implementation - a more sophisticated version would
         // explore the Hilbert space more intelligently
         let nearby_indices = self.get_nearby_indices(query_hilbert_index).await;
-        
+
         // Collect candidate vectors
-        let mut candidates: Vec<(Uuid, &VectorEntry)> = Vec::new();
+        let mut candidates: Vec<(Uuid, VectorEntry)> = Vec::new();
         {
             let vectors = self.vectors.read().await;
             let hilbert_map = self.hilbert_map.read().await;
-            
+
             for &index in &nearby_indices {
                 if let Some(ids) = hilbert_map.get(&index) {
                     for &id in ids {
                         if let Some(entry) = vectors.get(&id) {
-                            candidates.push((id, entry));
+                            candidates.push((id, entry.clone()));
                         }
                     }
                 }
             }
-            
+
             // If we have too few candidates, fall back to linear search
             if candidates.len() < limit * 4 && candidates.len() < vectors.len() / 2 {
                 debug!("Falling back to linear search for index '{}'", self.name);
-                candidates = vectors.iter().map(|(&id, entry)| (id, entry)).collect();
+                candidates = vectors
+                    .iter()
+                    .map(|(&id, entry)| (id, entry.clone()))
+                    .collect();
             }
         }
-        
+
         // Calculate distances
-        let mut results: Vec<SearchResult> = candidates.iter()
-            .map(|&(id, entry)| {
+        let mut results: Vec<SearchResult> = candidates
+            .into_iter()
+            .map(|(id, entry)| {
                 let score = self.distance_metric.calculate(query, &entry.vector);
                 SearchResult {
                     id,
@@ -287,7 +311,7 @@ impl VectorIndex {
                 }
             })
             .collect();
-            
+
         // Sort by score
         results.sort_by(|a, b| {
             if self.distance_metric.is_lower_better() {
@@ -296,32 +320,40 @@ impl VectorIndex {
                 b.score.partial_cmp(&a.score).unwrap()
             }
         });
-        
+
         // Limit results
         results.truncate(limit);
-        
+
         let elapsed = start.elapsed();
-        
+
         // Update metrics
         if let Some(metrics) = &self.metrics {
-            metrics.increment_counter(&format!("vector_index.{}.searches", self.name), 1).await;
-            metrics.record_histogram(
-                &format!("vector_index.{}.search_time_ms", self.name),
-                elapsed.as_millis() as u64
-            ).await;
+            metrics
+                .increment_counter(&format!("vector_index.{}.searches", self.name), 1)
+                .await;
+            metrics
+                .record_histogram(
+                    &format!("vector_index.{}.search_time_ms", self.name),
+                    elapsed.as_millis() as u64,
+                )
+                .await;
         }
-        
-        debug!("Search in index '{}' found {} results in {:?}", 
-               self.name, results.len(), elapsed);
-        
+
+        debug!(
+            "Search in index '{}' found {} results in {:?}",
+            self.name,
+            results.len(),
+            elapsed
+        );
+
         Ok(results)
     }
-    
+
     /// Get nearby indices in Hilbert space
     async fn get_nearby_indices(&self, center_index: u64) -> Vec<u64> {
         // Start with the exact index
         let mut indices = vec![center_index];
-        
+
         // Add some nearby indices (this is a simple implementation)
         // In a more sophisticated version, we would explore the Hilbert curve more intelligently
         let window_size = 5;
@@ -330,57 +362,59 @@ impl VectorIndex {
             if center_index >= i {
                 indices.push(center_index - i);
             }
-            
+
             // Add indices after
             indices.push(center_index + i);
         }
-        
+
         // Check if these indices exist in our map
         let hilbert_map = self.hilbert_map.read().await;
         indices.retain(|&idx| hilbert_map.contains_key(&idx));
-        
+
         indices
     }
-    
+
     /// Get the number of vectors in the index
     pub async fn count(&self) -> usize {
         self.vectors.read().await.len()
     }
-    
+
     /// Get detailed statistics about the index
     pub async fn stats(&self) -> IndexStats {
         let vectors = self.vectors.read().await;
         let hilbert_map = self.hilbert_map.read().await;
-        
+
         let mut bucket_sizes = Vec::new();
         for (_, ids) in hilbert_map.iter() {
             bucket_sizes.push(ids.len());
         }
-        
+
         bucket_sizes.sort_unstable();
-        
+
         let bucket_count = bucket_sizes.len();
         let total_vectors = vectors.len();
-        
+
         let min_bucket = bucket_sizes.first().cloned().unwrap_or(0);
         let max_bucket = bucket_sizes.last().cloned().unwrap_or(0);
-        
+
         let avg_bucket = if !bucket_sizes.is_empty() {
             bucket_sizes.iter().sum::<usize>() as f32 / bucket_sizes.len() as f32
         } else {
             0.0
         };
-        
+
         let median_bucket = if !bucket_sizes.is_empty() {
             if bucket_sizes.len() % 2 == 0 {
-                (bucket_sizes[bucket_sizes.len() / 2 - 1] + bucket_sizes[bucket_sizes.len() / 2]) as f32 / 2.0
+                (bucket_sizes[bucket_sizes.len() / 2 - 1] + bucket_sizes[bucket_sizes.len() / 2])
+                    as f32
+                    / 2.0
             } else {
                 bucket_sizes[bucket_sizes.len() / 2] as f32
             }
         } else {
             0.0
         };
-        
+
         IndexStats {
             name: self.name.clone(),
             vector_count: total_vectors,
@@ -400,28 +434,28 @@ impl VectorIndex {
 pub struct IndexStats {
     /// Name of the index
     pub name: String,
-    
+
     /// Number of vectors in the index
     pub vector_count: usize,
-    
+
     /// Dimensions of vectors in this index
     pub dimensions: usize,
-    
+
     /// Distance metric used for similarity search
     pub distance_metric: DistanceMetric,
-    
+
     /// Number of Hilbert space buckets
     pub bucket_count: usize,
-    
+
     /// Minimum bucket size
     pub min_bucket_size: usize,
-    
+
     /// Maximum bucket size
     pub max_bucket_size: usize,
-    
+
     /// Average bucket size
     pub avg_bucket_size: f32,
-    
+
     /// Median bucket size
     pub median_bucket_size: f32,
 }
@@ -430,108 +464,114 @@ pub struct IndexStats {
 mod tests {
     use super::*;
     use rand::Rng;
-    
+
     async fn create_test_index(vector_count: usize, dimensions: usize) -> VectorIndex {
         let index = VectorIndex::new("test_index", dimensions, DistanceMetric::Euclidean, None);
-        
+
         // Add random vectors
         for _ in 0..vector_count {
             let vector = Vector::random(dimensions);
             let mut metadata = HashMap::new();
             metadata.insert("test".to_string(), "value".to_string());
-            
+
             index.add(vector, Some(metadata)).await.unwrap();
         }
-        
+
         index
     }
-    
+
     #[tokio::test]
     async fn test_add_and_count() {
         let index = create_test_index(10, 3).await;
         assert_eq!(index.count().await, 10);
     }
-    
+
     #[tokio::test]
     async fn test_remove() {
         let index = VectorIndex::new("test_remove", 3, DistanceMetric::Euclidean, None);
-        
+
         // Add a vector
         let vector = Vector::random(3);
         let id = index.add(vector.clone(), None).await.unwrap();
         assert_eq!(index.count().await, 1);
-        
+
         // Remove it
         index.remove(id).await.unwrap();
         assert_eq!(index.count().await, 0);
-        
+
         // Try to remove it again (should fail)
         assert!(index.remove(id).await.is_err());
     }
-    
+
     #[tokio::test]
     async fn test_search() {
         let dimensions = 10;
         let vector_count = 100;
-        
+
         let index = create_test_index(vector_count, dimensions).await;
-        
+
         // Create a query vector
         let query = Vector::random(dimensions);
-        
+
         // Search for nearest vectors
         let results = index.search(&query, 5).await.unwrap();
-        
+
         // We should get 5 results
         assert_eq!(results.len(), 5);
-        
+
         // Scores should be sorted
         for i in 1..results.len() {
-            assert!(results[i-1].score <= results[i].score);
+            assert!(results[i - 1].score <= results[i].score);
         }
     }
-    
+
     #[tokio::test]
     async fn test_different_metrics() {
         // Test with different distance metrics
         let dimensions = 8;
         let vector_count = 50;
-        
+
         // Create some vectors with a known pattern
         let mut vectors = Vec::new();
         let mut rng = rand::thread_rng();
-        
+
         for _ in 0..vector_count {
             let values: Vec<f32> = (0..dimensions).map(|_| rng.gen_range(-1.0..1.0)).collect();
             vectors.push(Vector::new(values));
         }
-        
+
         // Create query vector
         let query = Vector::random(dimensions);
-        
+
         // Test each metric
-        for metric in [DistanceMetric::Euclidean, DistanceMetric::Cosine, 
-                      DistanceMetric::Manhattan, DistanceMetric::Hamming].iter() {
+        for metric in [
+            DistanceMetric::Euclidean,
+            DistanceMetric::Cosine,
+            DistanceMetric::Manhattan,
+            DistanceMetric::Hamming,
+        ]
+        .iter()
+        {
             let index = VectorIndex::new("test_metric", dimensions, *metric, None);
-            
+
             // Add all vectors
             for v in &vectors {
                 index.add(v.clone(), None).await.unwrap();
             }
-            
+
             // Search
             let results = index.search(&query, 5).await.unwrap();
             assert_eq!(results.len(), 5);
-            
+
             // Scores should be in ascending order for distance metrics
             if metric.is_lower_better() {
                 for i in 1..results.len() {
-                    assert!(results[i-1].score <= results[i].score);
+                    assert!(results[i - 1].score <= results[i].score);
                 }
             } else {
                 // Or descending order for similarity metrics
                 for i in 1..results.len() {
-                    assert!(results[i-1].score >= results[i].score);
+                    assert!(results[i - 1].score >= results[i].score);
                 }
             }
         }

--- a/tests/darwin.rs
+++ b/tests/darwin.rs
@@ -1,0 +1,65 @@
+use amazon_rose_forest::core::metrics::MetricsCollector;
+use amazon_rose_forest::darwin::exploration::ExplorationStrategy;
+use amazon_rose_forest::darwin::ritual::{RitualManager, RitualStage, RitualStageStatus};
+use amazon_rose_forest::darwin::self_improvement::{Modification, ModificationStatus};
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_add_to_archive() {
+    let metrics = Arc::new(MetricsCollector::new());
+    let strategy = ExplorationStrategy::new(metrics.clone());
+    let modification = Modification {
+        id: Uuid::new_v4(),
+        name: "test".into(),
+        description: "desc".into(),
+        code_changes: Vec::new(),
+        validation_metrics: HashMap::new(),
+        created_at: chrono::Utc::now(),
+        status: ModificationStatus::Proposed,
+    };
+    let mut metric_map = HashMap::new();
+    metric_map.insert("score".to_string(), 1.0);
+    strategy
+        .add_to_archive(modification, metric_map)
+        .await
+        .unwrap();
+    let stats = strategy.get_archive_stats().await;
+    assert_eq!(stats.total_entries, 1);
+}
+
+#[tokio::test]
+async fn test_ritual_stage_dependencies() {
+    let metrics = Arc::new(MetricsCollector::new());
+    let manager = RitualManager::new(metrics);
+    let stages = vec![
+        RitualStage {
+            name: "A".into(),
+            description: "A".into(),
+            status: RitualStageStatus::Pending,
+            depends_on: vec![],
+            artifacts: vec![],
+            started_at: None,
+            completed_at: None,
+        },
+        RitualStage {
+            name: "B".into(),
+            description: "B".into(),
+            status: RitualStageStatus::Pending,
+            depends_on: vec!["A".into()],
+            artifacts: vec![],
+            started_at: None,
+            completed_at: None,
+        },
+    ];
+    let ritual_id = manager.create_ritual("r", "d", stages).await.unwrap();
+    manager.start_stage(ritual_id, "A").await.unwrap();
+    // Starting B should fail because A not completed
+    assert!(manager.start_stage(ritual_id, "B").await.is_err());
+    manager
+        .complete_stage(ritual_id, "A", vec![])
+        .await
+        .unwrap();
+    assert!(manager.start_stage(ritual_id, "B").await.is_ok());
+}


### PR DESCRIPTION
## Summary
- fix moved variable bug when adding to archive
- reorganize stage checks in ritual manager to avoid simultaneous borrows
- simplify vector helpers and hilbert index search
- fix misc borrow issues
- add regression tests

## Testing
- `cargo test -- --test-threads=1` *(fails: could not compile `amazon-rose-forest` due to 18 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_68434d2f027483319540cbd265c75c0e