### PR TITLE
Add integration tests for core components

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all --verbose
     - name: Run benchmarks
       run: cargo bench --no-run

--- a/tests/centroid_crdt.rs
+++ b/tests/centroid_crdt.rs
@@ -1,0 +1,40 @@
+use amazon_rose_forest::core::centroid_crdt::{CentroidOperation, OperationType};
+use amazon_rose_forest::{CentroidCRDT, Vector};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_merge_concurrent_operations() {
+    let node_id1 = Uuid::new_v4();
+    let node_id2 = Uuid::new_v4();
+    let mut crdt1 = CentroidCRDT::new(node_id1);
+    let mut crdt2 = CentroidCRDT::new(node_id2);
+
+    let centroid_id = Uuid::new_v4();
+    let vector1 = Vector::new(vec![1.0, 2.0, 3.0]);
+    let vector2 = Vector::new(vec![4.0, 5.0, 6.0]);
+
+    let now = chrono::Utc::now();
+    let later = now + chrono::Duration::seconds(5);
+
+    let op1 = CentroidOperation {
+        id: Uuid::new_v4(),
+        centroid_id,
+        timestamp: now,
+        operation_type: OperationType::Create(vector1),
+    };
+
+    let op2 = CentroidOperation {
+        id: Uuid::new_v4(),
+        centroid_id,
+        timestamp: later,
+        operation_type: OperationType::Create(vector2.clone()),
+    };
+
+    crdt1.apply_operation(op1);
+    crdt2.apply_operation(op2);
+
+    crdt1.merge(&crdt2);
+
+    let centroid = crdt1.get_centroid(&centroid_id).unwrap();
+    assert_eq!(centroid.vector.values, vector2.values);
+}

--- a/tests/circuit_breaker.rs
+++ b/tests/circuit_breaker.rs
@@ -1,0 +1,23 @@
+use amazon_rose_forest::{CircuitBreaker, CircuitState};
+use std::time::Duration;
+
+#[tokio::test]
+async fn test_circuit_breaker_transitions() {
+    let cb = CircuitBreaker::new(
+        "test",
+        1,
+        Duration::from_millis(50),
+        Duration::from_millis(5),
+    );
+    assert_eq!(cb.get_state(), CircuitState::Closed);
+
+    cb.on_failure().await;
+    assert_eq!(cb.get_state(), CircuitState::Open);
+
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert!(cb.can_execute().await);
+    assert_eq!(cb.get_state(), CircuitState::HalfOpen);
+
+    cb.on_success().await;
+    assert_eq!(cb.get_state(), CircuitState::Closed);
+}

--- a/tests/shard_manager.rs
+++ b/tests/shard_manager.rs
@@ -1,0 +1,33 @@
+use amazon_rose_forest::{
+    core::metrics::MetricsCollector,
+    sharding::{manager::ShardManager, vector_index::DistanceMetric},
+    Vector,
+};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn test_shard_creation_and_search() {
+    let metrics = Arc::new(MetricsCollector::new());
+    let manager = ShardManager::new(metrics);
+
+    let shard_id = manager.create_shard("test_shard").await.unwrap();
+    manager
+        .create_vector_index(shard_id, "main", 3, DistanceMetric::Euclidean)
+        .await
+        .unwrap();
+
+    for _ in 0..5 {
+        let v = Vector::random(3);
+        manager.add_vector(shard_id, v, None).await.unwrap();
+    }
+
+    let results = manager
+        .search_vectors(shard_id, &Vector::random(3), 3)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 3);
+
+    let shard = manager.get_shard(shard_id).await.unwrap();
+    assert_eq!(shard.vector_count, 5);
+}


### PR DESCRIPTION
## Summary
- create async integration tests for shard manager, circuit breaker, and centroid CRDT
- run `cargo test --all` in CI workflow

## Testing
- `cargo test --all --quiet` *(fails: unresolved imports and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_684351158fbc8331af0fbb19ea557dfd