### PR TITLE
Consolidate sys_time utility

### DIFF
--- a/src/holochain/mod.rs
+++ b/src/holochain/mod.rs
@@ -7,6 +7,8 @@ pub mod utils;
 pub mod arbitration;
 pub mod transparency;
 
+pub use utils::sys_time;
+
 use hdk::prelude::*;
 use uuid::Uuid;
 use crate::core::vector::Vector;
@@ -88,12 +90,6 @@ pub struct AuditTrail {
     
     /// Timestamp with nanosecond precision
     pub timestamp: u64,
-}
-
-/// Get the current system time
-fn sys_time() -> ExternResult<u64> {
-    let time = sys_time_precise()?;
-    Ok(time.as_micros() as u64)
 }
 
 /// DNA properties configuration

--- a/src/holochain/zome.rs
+++ b/src/holochain/zome.rs
@@ -2,9 +2,8 @@
 
 use hdk::prelude::*;
 use crate::core::vector::Vector;
-use crate::holochain::{VectorEntry, CentroidEntry, AuditTrail};
+use crate::holochain::{VectorEntry, CentroidEntry, AuditTrail, sys_time};
 use crate::holochain::dna::get_distance_metric;
-use crate::holochain::utils::*;
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -205,10 +204,4 @@ fn create_audit_trail(action: &str, details: String) -> ExternResult<EntryHash> 
     create_link(path.path_entry_hash()?, entry_hash.clone(), link_tag)?;
     
     Ok(entry_hash)
-}
-
-/// Get the current system time
-pub fn sys_time() -> ExternResult<u64> {
-    let time = sys_time_precise()?;
-    Ok(time.as_micros() as u64)
 }


### PR DESCRIPTION
## Summary
- centralize `sys_time` in `src/holochain/utils.rs`
- expose the function from `holochain` module
- remove duplicates in `mod.rs` and `zome.rs`
- update imports to use the re-export

## Testing
- `cargo test --quiet` *(fails: use of unresolved crate `warp`)*

------
https://chatgpt.com/codex/tasks/task_e_6843511648b88331babccebfe5978e9f