### PR TITLE
Refactor Merkle proof hashing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ prometheus = "0.13"
 once_cell = "1.18.0"
 rand_distr = "0.4.3"
 sha2 = "0.10.7"  # Added SHA-2 cryptographic hash functions
+sha3 = { version = "0.10", optional = true }
+blake3 = { version = "1", optional = true }
+serde_bytes = "0.11"
 
 # Holochain dependencies
 hdk = "0.1.0"
@@ -46,9 +49,12 @@ rand = "0.8"
 rand_chacha = "0.3"
 
 [features]
-default = []
+default = ["sha2"]
 formal_verification = []
 holochain_conductor = ["holochain"]
+sha2 = []
+sha3 = ["dep:sha3"]
+blake3 = ["dep:blake3"]
 
 [[bench]]
 name = "vector_operations"

--- a/src/holochain/hash.rs
+++ b/src/holochain/hash.rs
@@ -1,0 +1,39 @@
+use digest::Digest;
+
+#[cfg(feature = "sha2")]
+use sha2::Sha256;
+#[cfg(feature = "sha3")]
+use sha3::Sha3_256;
+#[cfg(feature = "blake3")]
+use blake3::Hasher as Blake3;
+
+/// Extension trait providing a convenience `hash_bytes` method for digest
+/// implementations.
+pub trait DigestExt: Digest + Default {
+    /// Hash the provided bytes and return the digest bytes.
+    fn hash_bytes(bytes: &[u8]) -> Vec<u8> {
+        let mut hasher = Self::new();
+        hasher.update(bytes);
+        hasher.finalize().to_vec()
+    }
+}
+
+impl<T> DigestExt for T where T: Digest + Default {}
+
+/// Hash bytes using the default algorithm (SHA-256).
+#[cfg(feature = "sha3")]
+pub fn default_hash_bytes(bytes: &[u8]) -> Vec<u8> {
+    Sha3_256::hash_bytes(bytes)
+}
+
+#[cfg(feature = "blake3")]
+pub fn default_hash_bytes(bytes: &[u8]) -> Vec<u8> {
+    let mut hasher = Blake3::new();
+    hasher.update(bytes);
+    hasher.finalize().as_bytes().to_vec()
+}
+
+#[cfg(all(not(feature = "sha3"), not(feature = "blake3")))]
+pub fn default_hash_bytes(bytes: &[u8]) -> Vec<u8> {
+    Sha256::hash_bytes(bytes)
+}

--- a/src/holochain/mod.rs
+++ b/src/holochain/mod.rs
@@ -6,12 +6,14 @@ pub mod entries;
 pub mod utils;
 pub mod arbitration;
 pub mod transparency;
+pub mod hash;
 
 use hdk::prelude::*;
 use uuid::Uuid;
 use crate::core::vector::Vector;
 use crate::core::centroid::Centroid;
 use std::collections::HashMap;
+use serde::{Serialize, Deserialize};
 
 /// Entry definition for a vector in Holochain
 #[hdk_entry(id = "vector")]
@@ -80,8 +82,9 @@ pub struct AuditTrail {
     /// Who participated in validation
     pub validators: Vec<AgentPubKey>,
     
-    /// Cryptographic proof of decision process  
-    pub decision_proof: String,
+    /// Cryptographic proof of decision process
+    #[serde(with = "serde_bytes")]
+    pub decision_proof: Vec<u8>,
     
     /// Human-readable justification
     pub justification: String,

--- a/src/holochain/transparency.rs
+++ b/src/holochain/transparency.rs
@@ -4,7 +4,7 @@ use hdk::prelude::*;
 use crate::holochain::entries::AuditTrail;
 use crate::holochain::utils::{sys_time, create_path, timestamp_tag};
 use std::collections::HashMap;
-use sha2::{Sha256, Digest};
+use crate::holochain::hash::default_hash_bytes;
 
 /// Public API for transparency verification
 #[hdk_extern]
@@ -128,7 +128,7 @@ fn reconstruct_audit_trail(details: Details) -> ExternResult<AuditTrail> {
 }
 
 /// Verify a Merkle proof
-fn verify_merkle_proof(proof: &str) -> ExternResult<()> {
+fn verify_merkle_proof(proof: &[u8]) -> ExternResult<()> {
     // This is a stub that should be properly implemented
     // For now, we'll just check that the proof is not empty
     if proof.is_empty() {
@@ -138,23 +138,11 @@ fn verify_merkle_proof(proof: &str) -> ExternResult<()> {
 }
 
 /// Generate a Merkle proof
-fn generate_merkle_proof(content: &str) -> ExternResult<String> {
-    // Create a SHA-256 hash of the content as the base of our proof
-    let mut hasher = Sha256::new();
-    hasher.update(content.as_bytes());
-    let result = hasher.finalize();
-    
-    // Convert to hexadecimal string
-    let hash_string = result.iter()
-        .map(|b| format!("{:02x}", b))
-        .collect::<String>();
-    
+fn generate_merkle_proof(content: &str) -> ExternResult<Vec<u8>> {
     // In a real implementation, we would create a proper Merkle proof
-    // This would involve creating a Merkle tree and generating a proof
-    // For now, we'll use the hash as a simple placeholder
-    let proof = format!("merkle:sha256:{}", hash_string);
-    
-    Ok(proof)
+    // This would involve creating a Merkle tree and generating a proof.
+    // For now, hash the content as a placeholder proof.
+    Ok(default_hash_bytes(content.as_bytes()))
 }
 
 /// Count all decisions in the system

--- a/src/holochain/zome.rs
+++ b/src/holochain/zome.rs
@@ -192,7 +192,7 @@ fn create_audit_trail(action: &str, details: String) -> ExternResult<EntryHash> 
         action: action.to_string(),
         initiator: agent_info()?.agent_latest_pubkey,
         validators: vec![], // Would be populated during validation
-        decision_proof: "".to_string(), // Would be populated with a real merkle proof
+        decision_proof: Vec::new(), // Would be populated with a real merkle proof
         justification: details,
         timestamp: sys_time()?,
     };


### PR DESCRIPTION
## Summary
- add `DigestExt` trait for flexible hashing
- hash Merkle proofs as bytes
- store Merkle proof bytes in `AuditTrail`
- add optional features for alternative hash algorithms

## Testing
- `cargo check` *(fails: unresolved dependencies and unstable features)*

------
https://chatgpt.com/codex/tasks/task_e_6843511947f88331842320b1cdf283c0