### PR TITLE
Add holochain_conductor gating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rand_chacha = "0.3"
 [features]
 default = []
 formal_verification = []
-holochain_conductor = ["holochain"]
+holochain_conductor = ["holochain"] # enables conductor integration functions
 
 [[bench]]
 name = "vector_operations"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ Amazon Rose Forest integrates with Holochain to provide:
 cargo build
 ```
 
+To enable functions that interact with the Holochain conductor, compile with the
+`holochain_conductor` feature:
+
+```bash
+cargo build --features holochain_conductor
+```
+
 ### Running
 
 ```bash

--- a/src/holochain/dna.rs
+++ b/src/holochain/dna.rs
@@ -39,26 +39,54 @@ pub fn get_distance_metric() -> ExternResult<DistanceMetric> {
 }
 
 /// Create a new DNA template for a vector index
+#[cfg(feature = "holochain_conductor")]
 pub fn create_vector_index_dna(
     name: String,
     dimensions: usize,
     distance_metric: DistanceMetric,
-) -> DnaFile {
+) -> ExternResult<DnaFile> {
     // This would be implemented at conductor level in a real implementation
     // For now, this is a stub
     unimplemented!("Creating DNA files requires conductor integration")
 }
 
+#[cfg(not(feature = "holochain_conductor"))]
+pub fn create_vector_index_dna(
+    _name: String,
+    _dimensions: usize,
+    _distance_metric: DistanceMetric,
+) -> ExternResult<DnaFile> {
+    Err(wasm_error!(WasmErrorInner::Guest(
+        "holochain_conductor feature disabled".into()
+    )))
+}
+
 /// Register DNA with the conductor
-pub fn register_dna(dna: DnaFile) -> DnaHash {
+#[cfg(feature = "holochain_conductor")]
+pub fn register_dna(dna: DnaFile) -> ExternResult<DnaHash> {
     // This would be implemented at conductor level in a real implementation
     // For now, this is a stub
     unimplemented!("Registering DNA files requires conductor integration")
 }
 
+#[cfg(not(feature = "holochain_conductor"))]
+pub fn register_dna(_dna: DnaFile) -> ExternResult<DnaHash> {
+    Err(wasm_error!(WasmErrorInner::Guest(
+        "holochain_conductor feature disabled".into()
+    )))
+}
+
 /// Create a cell from a DNA and install it
+#[cfg(feature = "holochain_conductor")]
 pub fn create_and_install_cell(dna_hash: DnaHash) -> ExternResult<AgentPubKey> {
     // This would be implemented at conductor level in a real implementation
     // For now, this is a stub
     unimplemented!("Cell installation requires conductor integration")
+}
+
+#[cfg(not(feature = "holochain_conductor"))]
+pub fn create_and_install_cell(_dna_hash: DnaHash) -> ExternResult<AgentPubKey> {
+    Err(wasm_error!(WasmErrorInner::Guest(
+        "holochain_conductor feature disabled".into()
+    )))
 }


### PR DESCRIPTION
## Summary
- gate conductor-specific functions behind the `holochain_conductor` feature
- add fallback implementations when the feature is disabled
- document the optional feature in Cargo.toml and README

## Testing
- `cargo test` *(fails: could not compile `amazon-rose-forest`)*

------
https://chatgpt.com/codex/tasks/task_e_6843511c728483319fcd97da9013aa59