### PR TITLE
Clean duplicate imports

### DIFF
--- a/src/darwin/exploration.rs
+++ b/src/darwin/exploration.rs
@@ -1,12 +1,10 @@
 use anyhow::{anyhow, Result};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use anyhow::{Result, anyhow};
 use tracing::{info, warn, error, debug};
 use uuid::Uuid;
 use dashmap::DashMap;
 use tokio::sync::RwLock;
-use std::collections::{HashMap, HashSet};
 use rand::prelude::*;
 
 


### PR DESCRIPTION
## Summary
- deduplicate imports in exploration module

## Testing
- `cargo test` *(fails: could not compile `amazon-rose-forest`)*

------
https://chatgpt.com/codex/tasks/task_e_68486667ad208331b4238806ac0bac2f