### PR TITLE
Fix VectorIndex initialization in stats test

### DIFF
--- a/src/sharding/vector_index.rs
+++ b/src/sharding/vector_index.rs
@@ -591,7 +591,7 @@ mod tests {
     async fn test_stats() {
         // Build a small index with known vectors so we can predict stats
         let dimensions = 3;
-        let index = VectorIndex::new("stats_index", dimensions, DistanceMetric::Euclidean, None);
+        let index = VectorIndex::new("stats_index", dimensions, DistanceMetric::Euclidean, None).unwrap();
 
         let vectors = vec![
             Vector::new(vec![0.1, 0.2, 0.3]),


### PR DESCRIPTION
## Summary
- unwrap VectorIndex when creating the index in `test_stats`

## Testing
- `cargo test --no-run` *(fails: expected token `!` in `src/server/mod.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68486679b8988331822713276df2796c