### PR TITLE
[amazon_rose_forest] Remove unused imports from core modules

### DIFF
--- a/src/core/centroid.rs
+++ b/src/core/centroid.rs
@@ -1,7 +1,6 @@
-use std::sync::Arc;
+use crate::core::vector::Vector;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use crate::core::vector::Vector;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Centroid {
@@ -23,41 +22,41 @@ impl Centroid {
             updated_at: now,
         }
     }
-    
+
     pub fn update(&mut self, vector: &Vector) {
         // Update the centroid by moving it toward the new vector
         let weight_existing = self.count as f32;
         let weight_new = 1.0;
         let total_weight = weight_existing + weight_new;
-        
+
         let weighted_existing = self.vector.clone() * weight_existing;
         let weighted_new = vector.clone() * weight_new;
-        
+
         let combined = weighted_existing + weighted_new;
         let new_vector = combined / total_weight;
-        
+
         self.vector = new_vector;
         self.count += 1;
         self.updated_at = chrono::Utc::now();
     }
-    
+
     pub fn merge(&mut self, other: &Centroid) {
         let total_count = self.count + other.count;
         let weight_self = self.count as f32 / total_count as f32;
         let weight_other = other.count as f32 / total_count as f32;
-        
+
         let weighted_self = self.vector.clone() * weight_self;
         let weighted_other = other.vector.clone() * weight_other;
-        
+
         self.vector = weighted_self + weighted_other;
         self.count = total_count;
         self.updated_at = chrono::Utc::now();
     }
-    
+
     pub fn distance_to(&self, vector: &Vector) -> f32 {
         self.vector.euclidean_distance(vector)
     }
-    
+
     pub fn similarity_to(&self, vector: &Vector) -> f32 {
         self.vector.cosine_similarity(vector)
     }

--- a/src/core/vector.rs
+++ b/src/core/vector.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, Div, Mul, Sub};
-use wide::f32x4;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Vector {
@@ -46,16 +45,15 @@ impl Vector {
     }
 
     pub fn dot(&self, other: &Vector) -> f32 {
-      
-        assert_eq!(self.dimensions, other.dimensions, "Vectors must have the same dimensions");
-        
+        assert_eq!(
+            self.dimensions, other.dimensions,
+            "Vectors must have the same dimensions"
+        );
+
         self.dot_scalar(other)
-
-
     }
 
     fn dot_scalar(&self, other: &Vector) -> f32 {
-
         self.values
             .iter()
             .zip(other.values.iter())
@@ -92,12 +90,12 @@ impl Vector {
     }
 
     pub fn euclidean_distance(&self, other: &Vector) -> f32 {
+        assert_eq!(
+            self.dimensions, other.dimensions,
+            "Vectors must have the same dimensions"
+        );
 
-        assert_eq!(self.dimensions, other.dimensions, "Vectors must have the same dimensions");
-        
         self.euclidean_distance_scalar(other)
-
-
     }
 
     fn euclidean_distance_scalar(&self, other: &Vector) -> f32 {
@@ -110,7 +108,6 @@ impl Vector {
 
         sum_squared_diff.sqrt()
     }
-
 
     pub fn manhattan_distance(&self, other: &Vector) -> f32 {
         assert_eq!(
@@ -270,7 +267,10 @@ mod tests {
 
         // Test Euclidean distance
         let euclidean = v1.euclidean_distance(&v2);
-        assert!((euclidean - (3.0_f32 * 3.0_f32 + 3.0_f32 * 3.0_f32 + 3.0_f32 * 3.0_f32).sqrt()).abs() < 1e-6);
+        assert!(
+            (euclidean - (3.0_f32 * 3.0_f32 + 3.0_f32 * 3.0_f32 + 3.0_f32 * 3.0_f32).sqrt()).abs()
+                < 1e-6
+        );
 
         // Test Manhattan distance
         let manhattan = v1.manhattan_distance(&v2);


### PR DESCRIPTION
## Summary
- clean up unused imports in `src/core/vector.rs`
- clean up unused imports in `src/core/centroid.rs`

## Testing
- `cargo fmt --all` *(fails: cannot parse src/server/mod.rs)*
- `rustfmt src/core/vector.rs src/core/centroid.rs`
- `cargo clippy --all -- -D warnings` *(fails: could not compile `amazon-rose-forest`)*
- `cargo test --all` *(fails: could not compile `amazon-rose-forest`)*
- `cargo bench --no-run` *(fails: could not compile `amazon-rose-forest`)*

------
https://chatgpt.com/codex/tasks/task_e_6848e8ea3be8833183080a8475d9594f