### PR TITLE
[amazon_rose_forest] remove stray line and adjust imports

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,14 +1,13 @@
+use anyhow::{anyhow, Result};
+use prometheus::{Encoder, Registry, TextEncoder};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use prometheus::{Registry, TextEncoder, Encoder};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use anyhow::{Result, anyhow};
-use tracing::{info, error, debug, warn};
+use tracing::{debug, error, info, warn};
 
+#[rustfmt::skip]
 use warp::{Filter, Reply};
-main
-
 use crate::core::metrics::MetricsCollector;
 use crate::nerv::runtime::Runtime;
 use crate::sharding::manager::ShardManager;
@@ -18,19 +17,19 @@ use crate::sharding::manager::ShardManager;
 pub struct ServerConfig {
     /// Address to bind the server to
     pub address: String,
-    
+
     /// Port for the HTTP server
     pub port: u16,
-    
+
     /// Whether to enable the metrics endpoint
     pub enable_metrics: bool,
-    
+
     /// Path for the metrics endpoint
     pub metrics_path: String,
-    
+
     /// Whether to enable the API endpoint
     pub enable_api: bool,
-    
+
     /// Path for the API endpoint
     pub api_path: String,
 }
@@ -73,56 +72,56 @@ impl Server {
             server_handle: RwLock::new(None),
         }
     }
-    
+
     /// Start the server
     pub async fn start(&self) -> Result<()> {
         let addr = format!("{}:{}", self.config.address, self.config.port);
         let addr: SocketAddr = addr.parse()?;
-        
+
         let metrics = self.metrics.clone();
         let config = self.config.clone();
         let runtime = self.runtime.clone();
         let shard_manager = self.shard_manager.clone();
-        
+
         let server = warp::serve(self.routes(metrics, config, runtime, shard_manager));
-        
+
         info!("Starting server on {}", addr);
-        
+
         let (_, server_handle) = server.bind_with_graceful_shutdown(addr, async {
             tokio::signal::ctrl_c()
                 .await
                 .expect("Failed to listen for CTRL+C");
-                
+
             info!("Received shutdown signal, stopping server...");
         });
-        
+
         // Store server handle
         let mut handle = self.server_handle.write().await;
         *handle = Some(tokio::spawn(async move {
             server_handle.await;
             Ok(())
         }));
-        
+
         Ok(())
     }
-    
+
     /// Stop the server
     pub async fn stop(&self) -> Result<()> {
         let handle = {
             let mut handle = self.server_handle.write().await;
             handle.take()
         };
-        
+
         if let Some(handle) = handle {
             handle.abort();
             info!("Server stopped");
         } else {
             warn!("Server was not running");
         }
-        
+
         Ok(())
     }
-    
+
     /// Create the server routes
     fn routes(
         &self,
@@ -131,15 +130,14 @@ impl Server {
         runtime: Option<Arc<Runtime>>,
         shard_manager: Option<Arc<ShardManager>>,
     ) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-        let health_route = warp::path("health")
-            .map(move || {
-                debug!("Health check request received");
-                warp::reply::json(&serde_json::json!({
-                    "status": "ok",
-                    "version": crate::VERSION,
-                }))
-            });
-            
+        let health_route = warp::path("health").map(move || {
+            debug!("Health check request received");
+            warp::reply::json(&serde_json::json!({
+                "status": "ok",
+                "version": crate::VERSION,
+            }))
+        });
+
         let metrics_path = config.metrics_path.trim_start_matches('/').to_string();
         let metrics_route = if config.enable_metrics {
             let metrics_clone = metrics.clone();
@@ -166,10 +164,9 @@ impl Server {
                 })
                 .boxed()
         };
-        
+
         let api_path = config.api_path.trim_start_matches('/').to_string();
         let api_routes = if config.enable_api {
-            
             // API version endpoint
             let version_route = warp::path(api_path.clone())
                 .and(warp::path("version"))
@@ -180,7 +177,7 @@ impl Server {
                     .into_response()
                 })
                 .boxed();
-                
+
             // Statistics endpoint
             let stats_route = warp::path(api_path)
                 .and(warp::path("stats"))
@@ -206,7 +203,7 @@ impl Server {
                 })
                 .boxed()
         };
-        
+
         health_route.or(metrics_route).or(api_routes)
     }
 }


### PR DESCRIPTION
## Summary
- delete stray `main` line from server module
- keep import block immediately before `MetricsCollector` import

## Testing
- `cargo clippy --all -- -D warnings` *(fails)*
- `cargo test --all` *(fails to compile)*
- `cargo bench --no-run` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6848e91100e08331babc3fe0e483e0d6