### PR TITLE
[amazon_rose_forest] return error when conductor inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Amazon Rose Forest integrates with Holochain to provide:
 3. **Transparent Audit Trails**: Cryptographic proof of all system decisions
 4. **Agent-Centric Security**: Authentication and authorization via Holochain
 
+**Limitations:** conductor-level operations such as DNA creation, registration,
+and cell installation are not yet implemented. When compiled with the
+`holochain_conductor` feature these functions will return an error indicating
+the missing integration.
+
 ## Development
 
 ### Dependencies

--- a/src/holochain/dna.rs
+++ b/src/holochain/dna.rs
@@ -1,8 +1,13 @@
 //! DNA configuration and management for Holochain integration
+//!
+//! **Note:** Operations that require a running Holochain conductor (DNA
+//! creation, registration and cell installation) are not yet implemented. When
+//! compiled with the `holochain_conductor` feature these functions will return
+//! a descriptive `Err` indicating the missing integration.
 
-use hdk::prelude::*;
-use crate::sharding::vector_index::DistanceMetric;
 use crate::holochain::DnaProperties;
+use crate::sharding::vector_index::DistanceMetric;
+use hdk::prelude::*;
 
 /// Zome configuration for vector operations
 #[derive(Serialize, Deserialize, Debug)]
@@ -16,25 +21,27 @@ pub struct VectorZomeConfig {
 /// Get the DNA properties
 pub fn get_dna_properties() -> ExternResult<DnaProperties> {
     let dna_info = dna_info()?;
-    let props: DnaProperties = dna_info.properties
+    let props: DnaProperties = dna_info
+        .properties
         .try_into()
         .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
-        
+
     Ok(props)
 }
 
 /// Get the distance metric from DNA properties
 pub fn get_distance_metric() -> ExternResult<DistanceMetric> {
     let props = get_dna_properties()?;
-    
+
     match props.distance_metric.to_lowercase().as_str() {
         "euclidean" => Ok(DistanceMetric::Euclidean),
         "cosine" => Ok(DistanceMetric::Cosine),
         "manhattan" => Ok(DistanceMetric::Manhattan),
         "hamming" => Ok(DistanceMetric::Hamming),
-        _ => Err(wasm_error!(
-            WasmErrorInner::Guest(format!("Unknown distance metric: {}", props.distance_metric))
-        )),
+        _ => Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Unknown distance metric: {}",
+            props.distance_metric
+        )))),
     }
 }
 
@@ -45,9 +52,14 @@ pub fn create_vector_index_dna(
     dimensions: usize,
     distance_metric: DistanceMetric,
 ) -> ExternResult<DnaFile> {
-    // This would be implemented at conductor level in a real implementation
-    // For now, this is a stub
-    unimplemented!("Creating DNA files requires conductor integration")
+    // This would be implemented at conductor level in a real implementation.
+    // Until conductor integration exists, return an explanatory error so the
+    // caller knows why the operation failed.
+    let _ = (dimensions, distance_metric);
+    Err(wasm_error!(WasmErrorInner::Guest(format!(
+        "create_vector_index_dna `{}` requires conductor integration",
+        name
+    ))))
 }
 
 #[cfg(not(feature = "holochain_conductor"))]
@@ -64,9 +76,12 @@ pub fn create_vector_index_dna(
 /// Register DNA with the conductor
 #[cfg(feature = "holochain_conductor")]
 pub fn register_dna(dna: DnaFile) -> ExternResult<DnaHash> {
-    // This would be implemented at conductor level in a real implementation
-    // For now, this is a stub
-    unimplemented!("Registering DNA files requires conductor integration")
+    // This would be implemented at conductor level in a real implementation.
+    // Return an explanatory error until integration is available.
+    let _ = dna;
+    Err(wasm_error!(WasmErrorInner::Guest(
+        "register_dna requires conductor integration".into()
+    )))
 }
 
 #[cfg(not(feature = "holochain_conductor"))]
@@ -79,9 +94,12 @@ pub fn register_dna(_dna: DnaFile) -> ExternResult<DnaHash> {
 /// Create a cell from a DNA and install it
 #[cfg(feature = "holochain_conductor")]
 pub fn create_and_install_cell(dna_hash: DnaHash) -> ExternResult<AgentPubKey> {
-    // This would be implemented at conductor level in a real implementation
-    // For now, this is a stub
-    unimplemented!("Cell installation requires conductor integration")
+    // This would be implemented at conductor level in a real implementation.
+    // Until conductor integration exists, provide a clear error message.
+    let _ = dna_hash;
+    Err(wasm_error!(WasmErrorInner::Guest(
+        "create_and_install_cell requires conductor integration".into()
+    )))
 }
 
 #[cfg(not(feature = "holochain_conductor"))]


### PR DESCRIPTION
## Summary
- avoid unimplemented! in Holochain DNA functions
- document conductor limitations in README

## Testing
- `cargo clippy --all -- -D warnings` *(fails: unused imports and other errors)*
- `cargo test --all` *(fails: use of moved value `features`)*
- `cargo bench --no-run` *(fails: could not compile `amazon-rose-forest`)*

------
https://chatgpt.com/codex/tasks/task_e_6870746c51a88331b42b2b89651328e0