### PR TITLE
[amazon_rose_forest] Document endpoint toggles and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ Amazon Rose Forest can be configured through a JSON configuration file. Here's a
 }
 ```
 
+### Server Options
+
+The HTTP server exposes metrics and API endpoints. The following configuration
+flags control whether these endpoints are available:
+
+- `enable_metrics` &ndash; when set to `false`, requests to the metrics path
+  return `404 Not Found` with the body `"Metrics endpoint disabled"`.
+- `enable_api` &ndash; when set to `false`, all API requests return `404 Not
+  Found` with the body `"API endpoint disabled"`.
+
 ## License
 
 MIT

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -123,7 +123,7 @@ impl Server {
     }
 
     /// Create the server routes
-    fn routes(
+    pub fn routes(
         &self,
         metrics: Arc<MetricsCollector>,
         config: ServerConfig,

--- a/tests/server_endpoints.rs
+++ b/tests/server_endpoints.rs
@@ -1,0 +1,36 @@
+use amazon_rose_forest::core::metrics::MetricsCollector;
+use amazon_rose_forest::server::{Server, ServerConfig};
+use std::sync::Arc;
+use warp::Filter;
+
+#[tokio::test]
+async fn disabled_endpoints_return_404() {
+    let metrics = Arc::new(MetricsCollector::new());
+    let config = ServerConfig {
+        address: "127.0.0.1".into(),
+        port: 0,
+        enable_metrics: false,
+        metrics_path: "/metrics".into(),
+        enable_api: false,
+        api_path: "/api".into(),
+    };
+
+    let server = Server::new(config.clone(), metrics.clone(), None, None);
+    let filter = server.routes(metrics, config, None, None);
+
+    let resp = warp::test::request()
+        .method("GET")
+        .path("/metrics")
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), 404);
+    assert_eq!(resp.body(), "Metrics endpoint disabled");
+
+    let resp = warp::test::request()
+        .method("GET")
+        .path("/api/version")
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), 404);
+    assert_eq!(resp.body(), "API endpoint disabled");
+}


### PR DESCRIPTION
## Summary
- mention `enable_metrics` and `enable_api` options in README
- expose `Server::routes` for testing
- add integration test covering disabled endpoints

## Testing
- `cargo clippy --all`
- `cargo test --all` *(fails: sharding::hilbert tests)*
- `cargo bench --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6877c03b2a7083319f34596e5f93d026