### PR TITLE
[amazon_rose_forest] Resolve merge conflicts

### DIFF
--- a/src/core/centroid_crdt.rs
+++ b/src/core/centroid_crdt.rs
@@ -2,10 +2,7 @@ use crate::core::centroid::Centroid;
 use crate::core::vector::Vector;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-<<<<<<< Updated upstream
 use thiserror::Error;
-=======
->>>>>>> Stashed changes
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,15 +63,11 @@ impl CentroidCRDT {
         centroid_id
     }
 
-<<<<<<< Updated upstream
     pub fn update_centroid(
         &mut self,
         centroid_id: Uuid,
         vector: Vector,
     ) -> Result<(), CentroidCRDTError> {
-=======
-    pub fn update_centroid(&mut self, centroid_id: Uuid, vector: Vector) -> Result<(), String> {
->>>>>>> Stashed changes
         if !self.centroids.contains_key(&centroid_id) {
             return Err(CentroidCRDTError::NotFound(centroid_id));
         }
@@ -91,11 +84,7 @@ impl CentroidCRDT {
         Ok(())
     }
 
-<<<<<<< Updated upstream
     pub fn delete_centroid(&mut self, centroid_id: Uuid) -> Result<(), CentroidCRDTError> {
-=======
-    pub fn delete_centroid(&mut self, centroid_id: Uuid) -> Result<(), String> {
->>>>>>> Stashed changes
         if !self.centroids.contains_key(&centroid_id) {
             return Err(CentroidCRDTError::NotFound(centroid_id));
         }
@@ -177,30 +166,21 @@ impl CentroidCRDT {
         self.centroids.values().collect()
     }
 
-<<<<<<< Updated upstream
     pub fn find_nearest(
         &self,
         vector: &Vector,
         limit: usize,
     ) -> Result<Vec<(&Centroid, f32)>, CentroidCRDTError> {
-=======
-    pub fn find_nearest(&self, vector: &Vector, limit: usize) -> Vec<(&Centroid, f32)> {
->>>>>>> Stashed changes
         let mut distances: Vec<(&Centroid, f32)> = self
             .centroids
             .values()
             .map(|c| (c, c.distance_to(vector)))
             .collect();
-<<<<<<< Updated upstream
         if distances.iter().any(|(_, d)| !d.is_finite()) {
             return Err(CentroidCRDTError::InvalidDistance);
         }
 
         distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-=======
-
-        distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
->>>>>>> Stashed changes
         distances.truncate(limit);
         Ok(distances)
     }
@@ -235,12 +215,8 @@ mod tests {
         let centroid_id = crdt.create_centroid(vector1);
 
         let vector2 = Vector::new(vec![4.0, 5.0, 6.0]);
-<<<<<<< Updated upstream
         let res = crdt.update_centroid(centroid_id, vector2);
         assert!(res.is_ok());
-=======
-        crdt.update_centroid(centroid_id, vector2).unwrap();
->>>>>>> Stashed changes
 
         assert_eq!(crdt.operations.len(), 2);
 
@@ -263,12 +239,8 @@ mod tests {
         let vector = Vector::new(vec![1.0, 2.0, 3.0]);
         let centroid_id = crdt.create_centroid(vector.clone());
 
-<<<<<<< Updated upstream
         let res = crdt.delete_centroid(centroid_id);
         assert!(res.is_ok());
-=======
-        crdt.delete_centroid(centroid_id).unwrap();
->>>>>>> Stashed changes
 
         assert_eq!(crdt.centroids.len(), 0);
         assert_eq!(crdt.operations.len(), 2);

--- a/src/darwin/exploration.rs
+++ b/src/darwin/exploration.rs
@@ -351,13 +351,9 @@ impl ExplorationStrategy {
             // Compare based on sum of metrics (higher is better)
             let a_score: f32 = a.metrics.values().sum();
             let b_score: f32 = b.metrics.values().sum();
-<<<<<<< Updated upstream
             a_score
                 .partial_cmp(&b_score)
                 .unwrap_or(std::cmp::Ordering::Equal)
-=======
-            a_score.partial_cmp(&b_score).unwrap()
->>>>>>> Stashed changes
         })
     }
 
@@ -382,11 +378,7 @@ impl ExplorationStrategy {
         let entry = ArchiveEntry {
             modification,
             metrics,
-<<<<<<< Updated upstream
             features: archive_features,
-=======
-            features: features.clone(),
->>>>>>> Stashed changes
             added_at: chrono::Utc::now(),
         };
 

--- a/src/sharding/manager.rs
+++ b/src/sharding/manager.rs
@@ -243,15 +243,11 @@ impl ShardManager {
         Ok(())
     }
 
-<<<<<<< Updated upstream
     pub async fn start_migration(
         self: Arc<Self>,
         shard_id: Uuid,
         target_node: &str,
     ) -> Result<Uuid> {
-=======
-    pub async fn start_migration(&self, shard_id: Uuid, target_node: &str) -> Result<Uuid> {
->>>>>>> Stashed changes
         // Verify the shard exists
         let shard = self.get_shard(shard_id).await?;
 
@@ -470,26 +466,4 @@ impl ShardManager {
 
         Ok(distribution)
     }
-<<<<<<< Updated upstream
 }
-=======
-}
-
-// Support cloning for the manager to allow sharing between threads
-impl Clone for ShardManager {
-    fn clone(&self) -> Self {
-        // Note: This creates a new instance with the same node_id and metrics
-        // but empty collections. The collections are meant to be
-        // accessed through the original instance's RwLocks.
-        Self {
-            metrics: self.metrics.clone(),
-            node_id: self.node_id.clone(),
-            shards: RwLock::new(HashMap::new()),
-            shard_assignments: RwLock::new(HashMap::new()),
-            migrations: RwLock::new(HashMap::new()),
-            indices: RwLock::new(HashMap::new()),
-            shard_loads: RwLock::new(HashMap::new()),
-        }
-    }
-}
->>>>>>> Stashed changes


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in Darwin exploration
- fix merge conflicts in centroid CRDT
- tidy merge conflict leftovers in shard manager

## Testing
- `cargo fmt --all` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo clippy --all` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo test --all` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo bench --no-run` *(fails: duplicate key `rand` in Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_688596a303f08331841aa6c779b00948