### PR TITLE
[amazon_rose_forest] Add runtime shutdown tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ rand_distr = "0.4"
 sha2 = "0.10.7"  # Added SHA-2 cryptographic hash functions
 sha3 = { version = "0.10", optional = true }
 blake3 = { version = "1", optional = true }
-rand = "0.8"
 serde_bytes = "0.11"
 wide = "0.7"
 warp = "0.3"

--- a/src/nerv/runtime.rs
+++ b/src/nerv/runtime.rs
@@ -73,4 +73,9 @@ impl Runtime {
     pub fn shard_manager(&self) -> Option<Arc<ShardManager>> {
         self.shard_manager.clone()
     }
+
+    /// Expose the shutdown sender for testing and external monitoring
+    pub fn shutdown_sender(&self) -> Option<mpsc::Sender<()>> {
+        self.shutdown_tx.clone()
+    }
 }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,0 +1,29 @@
+use amazon_rose_forest::{core::metrics::MetricsCollector, nerv::runtime::Runtime};
+use std::sync::Arc;
+use tokio::time::{timeout, Duration};
+
+#[tokio::test]
+async fn runtime_start_initializes_shard_manager() {
+    let metrics = Arc::new(MetricsCollector::new());
+    let mut runtime = Runtime::new(metrics.clone());
+    runtime.start().await.unwrap();
+    assert!(runtime.shard_manager().is_some());
+    runtime.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn runtime_stop_sends_shutdown_signal() {
+    let metrics = Arc::new(MetricsCollector::new());
+    let mut runtime = Runtime::new(metrics);
+    runtime.start().await.unwrap();
+
+    runtime.stop().await.unwrap();
+
+    if let Some(tx) = runtime.shutdown_sender() {
+        // The channel should close once the background task handles the shutdown message
+        let closed = timeout(Duration::from_secs(1), tx.closed()).await;
+        assert!(closed.is_ok(), "shutdown signal not processed in time");
+    } else {
+        panic!("shutdown channel missing");
+    }
+}


### PR DESCRIPTION
## Summary
- expose the runtime shutdown sender
- add async tests for Runtime start/stop behavior
- fix duplicate rand entry in Cargo.toml

## Testing
- `cargo fmt --all` *(fails: cannot parse centroid_crdt.rs)*
- `cargo build` *(fails: cannot parse centroid_crdt.rs)*
- `cargo +nightly build --features holochain_conductor` *(fails: SQL format assertion in lair_keystore)*
- `cargo clippy --all` *(fails: cannot parse centroid_crdt.rs)*
- `cargo test --all` *(fails: cannot parse centroid_crdt.rs)*
- `cargo bench --no-run` *(fails: cannot parse centroid_crdt.rs)*

------
https://chatgpt.com/codex/tasks/task_e_688596a59140833192f2e4e2543ef305