### PR TITLE
[amazon_rose_forest] Remove git credential files

### DIFF
--- a/.git-credentials
+++ b/.git-credentials
@@ -1,1 +1,0 @@
-https://${GITHUB_TOKEN}@github.com

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,5 +1,0 @@
-[credential]
-	helper = store
-[user]
-	name = Anthony Garrett
-	email = kalisam@gmail.DOtcom

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Cargo.lock
 .vscode/
 .DS_Store
 /.vs
+.git-credentials
+.gitconfig


### PR DESCRIPTION
## Summary
- delete `.git-credentials` and `.gitconfig`
- ignore these files in `.gitignore`

## Testing
- `cargo fmt --all` *(fails: duplicate key `rand` in dependencies)*
- `cargo build` *(fails: duplicate key `rand` in dependencies)*
- `cargo +nightly build --features holochain_conductor` *(fails: duplicate key)*
- `cargo clippy --all` *(fails: duplicate key `rand` in dependencies)*
- `cargo test --all` *(fails: duplicate key `rand` in dependencies)*
- `cargo bench --no-run` *(fails: duplicate key `rand` in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6885971fa0c88331b4deba11ebac1a03