### PR TITLE
[amazon_rose_forest] fix server start time locking

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -78,7 +78,7 @@ impl Server {
 
     /// Start the server
     pub async fn start(&mut self) -> Result<()> {
-        self.start_time = Instant::now();
+        *self.start_time.write().unwrap() = Some(Instant::now());
         let addr = format!("{}:{}", self.config.address, self.config.port);
         let addr: SocketAddr = addr.parse()?;
       


### PR DESCRIPTION
## Summary
- store `Instant::now()` inside inner `RwLock` for `Server.start`

## Testing
- `cargo fmt --all` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo clippy --all` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo build` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo +nightly build --features holochain_conductor` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo test --all` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo bench --no-run` *(fails: duplicate key `rand` in Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_6885976958b48331bd361192b1b434ef