### PR TITLE
[amazon_rose_forest] add websocket search route

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -11,6 +11,11 @@ use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
+use warp::ws::{Message, WebSocket};
+use futures::{StreamExt, SinkExt};
+use tokio::sync::broadcast;
+use crate::server::api::{SearchVectorsRequest, ErrorResponse, create_vector, convert_search_results};
+use uuid::Uuid;
 use warp::{Filter, Reply};
 
 /// Server configuration
@@ -121,6 +126,50 @@ impl Server {
         Ok(())
     }
 
+    async fn handle_ws_search(socket: WebSocket, manager: Arc<ShardManager>) {
+        let (mut tx_ws, mut rx_ws) = socket.split();
+        while let Some(Ok(msg)) = rx_ws.next().await {
+            if !msg.is_text() {
+                continue;
+            }
+            let req: Result<SearchVectorsRequest, _> = serde_json::from_str(msg.to_str().unwrap());
+            let req = match req {
+                Ok(r) => r,
+                Err(e) => {
+                    let err = ErrorResponse { error: e.to_string() };
+                    let _ = tx_ws.send(Message::text(serde_json::to_string(&err).unwrap())).await;
+                    continue;
+                }
+            };
+
+            let query = create_vector(req.query_vector.clone());
+            let results = match manager.search_vectors(req.shard_id, &query, req.limit).await {
+                Ok(r) => r,
+                Err(e) => {
+                    let err = ErrorResponse { error: e.to_string() };
+                    let _ = tx_ws.send(Message::text(serde_json::to_string(&err).unwrap())).await;
+                    continue;
+                }
+            };
+
+            let api_results = convert_search_results(results);
+            let (tx, mut rx) = broadcast::channel::<String>(16);
+            let mut tx_ws_clone = tx_ws.clone();
+            let forward = tokio::spawn(async move {
+                while let Ok(res) = rx.recv().await {
+                    if tx_ws_clone.send(Message::text(res)).await.is_err() {
+                        break;
+                    }
+                }
+            });
+            for r in api_results {
+                let _ = tx.send(serde_json::to_string(&r).unwrap());
+            }
+            drop(tx);
+            let _ = forward.await;
+        }
+    }
+
 
     /// Get the Warp filter for this server
     pub fn filter(
@@ -228,6 +277,25 @@ impl Server {
                 .boxed()
         };
 
-        health_route.or(metrics_route).or(api_routes)
+        let ws_search_route = {
+            let manager_opt = shard_manager.clone();
+            warp::path("ws")
+                .and(warp::path("search"))
+                .and(warp::ws())
+                .map(move |ws: warp::ws::Ws| {
+                    let manager_clone = manager_opt.clone();
+                    ws.on_upgrade(move |socket| async move {
+                        if let Some(manager) = manager_clone {
+                            Server::handle_ws_search(socket, manager).await;
+                        }
+                    })
+                })
+                .boxed()
+        };
+
+        health_route
+            .or(metrics_route)
+            .or(api_routes)
+            .or(ws_search_route)
     }
 }

--- a/tests/server_endpoints.rs
+++ b/tests/server_endpoints.rs
@@ -1,5 +1,8 @@
 use amazon_rose_forest::core::metrics::MetricsCollector;
 use amazon_rose_forest::server::{Server, ServerConfig};
+use amazon_rose_forest::server::api::{SearchVectorsRequest, SearchResult};
+use amazon_rose_forest::{Vector, sharding::manager::ShardManager, sharding::vector_index::DistanceMetric};
+use warp::ws::Message;
 use std::sync::Arc;
 use warp::Filter;
 
@@ -33,4 +36,46 @@ async fn disabled_endpoints_return_404() {
         .await;
     assert_eq!(resp.status(), 404);
     assert_eq!(resp.body(), "API endpoint disabled");
+}
+
+#[tokio::test]
+async fn websocket_search_returns_results() {
+    let metrics = Arc::new(MetricsCollector::new());
+    let manager = Arc::new(ShardManager::new(metrics.clone()));
+    let shard_id = manager.create_shard("test").await.unwrap();
+    manager
+        .create_vector_index(shard_id, "main", 3, DistanceMetric::Euclidean)
+        .await
+        .unwrap();
+
+    manager
+        .add_vector(shard_id, Vector::new(vec![0.0, 0.0, 0.0]), None)
+        .await
+        .unwrap();
+    manager
+        .add_vector(shard_id, Vector::new(vec![1.0, 1.0, 1.0]), None)
+        .await
+        .unwrap();
+
+    let config = ServerConfig::default();
+    let server = Server::new(config.clone(), metrics.clone(), None, Some(manager.clone()));
+    let filter = server.routes(metrics, config, None, Some(manager));
+
+    let mut client = warp::test::ws()
+        .path("/ws/search")
+        .handshake(filter)
+        .await;
+
+    let req = SearchVectorsRequest {
+        shard_id,
+        query_vector: vec![0.0, 0.0, 0.0],
+        limit: 1,
+    };
+    client
+        .send(Message::text(serde_json::to_string(&req).unwrap()))
+        .await;
+
+    let msg = client.recv().await.unwrap();
+    assert!(msg.is_text());
+    let _res: SearchResult = serde_json::from_str(msg.to_str().unwrap()).unwrap();
 }


### PR DESCRIPTION
## Summary
- expose `/ws/search` WebSocket endpoint
- broadcast search results as they are found
- test WebSocket search behaviour

## Testing
- `cargo fmt --all` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo clippy --all --quiet` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo test --all --quiet` *(fails: duplicate key `rand` in Cargo.toml)*
- `cargo bench --no-run --quiet` *(fails: duplicate key `rand` in Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68859792f5a4833180a0deb9fe4eab39