### PR TITLE
[amazon_rose_forest] Add minimal REST endpoints

### DIFF
--- a/tests/server_endpoints.rs
+++ b/tests/server_endpoints.rs
@@ -1,10 +1,12 @@
 use amazon_rose_forest::core::metrics::MetricsCollector;
+use amazon_rose_forest::server::api::{SearchResult, SearchVectorsRequest};
 use amazon_rose_forest::server::{Server, ServerConfig};
-use amazon_rose_forest::server::api::{SearchVectorsRequest, SearchResult};
-use amazon_rose_forest::{Vector, sharding::manager::ShardManager, sharding::vector_index::DistanceMetric};
-use warp::ws::Message;
+use amazon_rose_forest::{
+    sharding::manager::ShardManager, sharding::vector_index::DistanceMetric, Vector,
+};
 use std::sync::Arc;
 use warp::http::StatusCode;
+use warp::ws::Message;
 use warp::Filter;
 
 use serde_json::Value;
@@ -64,10 +66,7 @@ async fn websocket_search_returns_results() {
     let server = Server::new(config.clone(), metrics.clone(), None, Some(manager.clone()));
     let filter = server.routes(metrics, config, None, Some(manager));
 
-    let mut client = warp::test::ws()
-        .path("/ws/search")
-        .handshake(filter)
-        .await;
+    let mut client = warp::test::ws().path("/ws/search").handshake(filter).await;
 
     let req = SearchVectorsRequest {
         shard_id,
@@ -81,7 +80,9 @@ async fn websocket_search_returns_results() {
     let msg = client.recv().await.unwrap();
     assert!(msg.is_text());
     let _res: SearchResult = serde_json::from_str(msg.to_str().unwrap()).unwrap();
- 
+}
+
+#[tokio::test]
 async fn enabled_endpoints_return_data() {
     let metrics = Arc::new(MetricsCollector::new());
     metrics.increment_counter("test_counter", 1).await;
@@ -118,4 +119,70 @@ async fn enabled_endpoints_return_data() {
     assert_eq!(resp.status(), StatusCode::OK);
     let body_json: Value = serde_json::from_slice(resp.body()).unwrap();
     assert_eq!(body_json["version"], amazon_rose_forest::VERSION);
+}
+
+#[tokio::test]
+async fn api_vector_endpoints_work() {
+    let metrics = Arc::new(MetricsCollector::new());
+    let manager = Arc::new(ShardManager::new(metrics.clone()));
+    let config = ServerConfig::default();
+    let server = Server::new(config.clone(), metrics.clone(), None, Some(manager.clone()));
+    let filter = server.routes(metrics, config, None, Some(manager.clone()));
+
+    let create_req = amazon_rose_forest::server::api::CreateShardRequest {
+        name: "test".into(),
+    };
+    let resp = warp::test::request()
+        .method("POST")
+        .path("/api/shards")
+        .json(&create_req)
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let shard_resp: amazon_rose_forest::server::api::CreateShardResponse =
+        serde_json::from_slice(resp.body()).unwrap();
+    let shard_id = shard_resp.shard_id;
+
+    let index_req = amazon_rose_forest::server::api::CreateIndexRequest {
+        shard_id,
+        name: "main".into(),
+        dimensions: 3,
+        distance_metric: "euclidean".into(),
+    };
+    let resp = warp::test::request()
+        .method("POST")
+        .path("/api/indexes")
+        .json(&index_req)
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let add_req = amazon_rose_forest::server::api::AddVectorRequest {
+        shard_id,
+        vector: vec![0.0, 0.0, 0.0],
+        metadata: None,
+    };
+    let resp = warp::test::request()
+        .method("POST")
+        .path("/api/vectors")
+        .json(&add_req)
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let search_req = SearchVectorsRequest {
+        shard_id,
+        query_vector: vec![0.0, 0.0, 0.0],
+        limit: 1,
+    };
+    let resp = warp::test::request()
+        .method("POST")
+        .path("/api/search")
+        .json(&search_req)
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let search_resp: amazon_rose_forest::server::api::SearchVectorsResponse =
+        serde_json::from_slice(resp.body()).unwrap();
+    assert_eq!(search_resp.results.len(), 1);
 }


### PR DESCRIPTION
## Summary
- add JSON body helper and implement POST routes for shards, indexes, vectors, and search
- exercise new endpoints with integration tests

## Testing
- `cargo fmt --all` *(fails: unexpected closing delimiter in src/darwin/self_improvement.rs)*
- `cargo clippy --all -- -D warnings` *(fails: unexpected closing delimiter in src/darwin/self_improvement.rs)*
- `cargo test --all` *(fails: unexpected closing delimiter in src/darwin/self_improvement.rs)*
- `cargo bench --no-run` *(fails: unexpected closing delimiter in src/darwin/self_improvement.rs)*

------
https://chatgpt.com/codex/tasks/task_e_688fcf48a0f0833196322da4a037c928