### PR TITLE
[amazon_rose_forest] instrument HTTP request metrics

### DIFF
--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -9,6 +9,32 @@ pub static REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);
 
 // Define metrics
 
+// HTTP server metrics
+pub static INCOMING_REQUESTS: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        "incoming_requests_total",
+        "Number of incoming HTTP requests",
+        &["method", "path"],
+        REGISTRY.clone(),
+    )
+    .expect("Failed to create incoming requests counter")
+});
+
+pub static HTTP_REQUEST_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        HistogramOpts::new(
+            "http_request_duration_seconds",
+            "Duration of HTTP requests in seconds",
+        )
+        .buckets(vec![
+            0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0,
+        ]),
+        &["method", "path", "status"],
+        REGISTRY.clone(),
+    )
+    .expect("Failed to create HTTP request duration histogram")
+});
+
 // Vector operations
 pub static VECTOR_OPS_COUNTER: Lazy<CounterVec> = Lazy::new(|| {
     register_counter_vec!(

--- a/tests/server_metrics.rs
+++ b/tests/server_metrics.rs
@@ -1,0 +1,128 @@
+use amazon_rose_forest::core::metrics::MetricsCollector;
+use amazon_rose_forest::server::metrics::{HTTP_REQUEST_DURATION, INCOMING_REQUESTS};
+use amazon_rose_forest::server::{Server, ServerConfig};
+use std::sync::Arc;
+use warp::Filter;
+
+#[tokio::test]
+async fn records_request_metrics() {
+    INCOMING_REQUESTS.reset();
+    HTTP_REQUEST_DURATION.reset();
+
+    let metrics = Arc::new(MetricsCollector::new());
+    let server = Server::new(ServerConfig::default(), metrics, None, None);
+
+    // Health endpoint
+    let filter = server.filter();
+    let resp = warp::test::request()
+        .method("GET")
+        .path("/health")
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), warp::http::StatusCode::OK);
+    assert_eq!(
+        INCOMING_REQUESTS
+            .with_label_values(&["GET", "/health"])
+            .get(),
+        1.0
+    );
+    assert_eq!(
+        HTTP_REQUEST_DURATION
+            .with_label_values(&["GET", "/health", "200"])
+            .get_sample_count(),
+        1
+    );
+
+    // Metrics endpoint
+    let filter = server.filter();
+    let resp = warp::test::request()
+        .method("GET")
+        .path("/metrics")
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), warp::http::StatusCode::OK);
+    assert_eq!(
+        INCOMING_REQUESTS
+            .with_label_values(&["GET", "/metrics"])
+            .get(),
+        1.0
+    );
+    assert_eq!(
+        HTTP_REQUEST_DURATION
+            .with_label_values(&["GET", "/metrics", "200"])
+            .get_sample_count(),
+        1
+    );
+
+    // API version endpoint with POST
+    let filter = server.filter();
+    let resp = warp::test::request()
+        .method("POST")
+        .path("/api/version")
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), warp::http::StatusCode::OK);
+    assert_eq!(
+        INCOMING_REQUESTS
+            .with_label_values(&["POST", "/api/version"])
+            .get(),
+        1.0
+    );
+    assert_eq!(
+        HTTP_REQUEST_DURATION
+            .with_label_values(&["POST", "/api/version", "200"])
+            .get_sample_count(),
+        1
+    );
+
+    // WebSocket handshake
+    let filter = server.filter();
+    let resp = warp::test::request()
+        .method("GET")
+        .path("/ws/search")
+        .header("connection", "upgrade")
+        .header("upgrade", "websocket")
+        .header("sec-websocket-version", "13")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), warp::http::StatusCode::SWITCHING_PROTOCOLS);
+    assert_eq!(
+        INCOMING_REQUESTS
+            .with_label_values(&["GET", "/ws/search"])
+            .get(),
+        1.0
+    );
+    assert_eq!(
+        HTTP_REQUEST_DURATION
+            .with_label_values(&["GET", "/ws/search", "101"])
+            .get_sample_count(),
+        1
+    );
+
+    // Disabled metrics endpoint should return 404
+    INCOMING_REQUESTS.reset();
+    HTTP_REQUEST_DURATION.reset();
+    let mut cfg = ServerConfig::default();
+    cfg.enable_metrics = false;
+    let server_disabled = Server::new(cfg, Arc::new(MetricsCollector::new()), None, None);
+    let filter = server_disabled.filter();
+    let resp = warp::test::request()
+        .method("GET")
+        .path("/metrics")
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), warp::http::StatusCode::NOT_FOUND);
+    assert_eq!(
+        INCOMING_REQUESTS
+            .with_label_values(&["GET", "/metrics"])
+            .get(),
+        1.0
+    );
+    assert_eq!(
+        HTTP_REQUEST_DURATION
+            .with_label_values(&["GET", "/metrics", "404"])
+            .get_sample_count(),
+        1
+    );
+}


### PR DESCRIPTION
## Summary
- add Prometheus counters/histograms for HTTP request counts and durations
- wrap server routes with a helper filter to record request metrics
- add integration test covering health, metrics, API and websocket routes with 404 coverage

## Testing
- `cargo fmt --all` *(fails: unexpected closing delimiter in self_improvement.rs)*
- `cargo clippy --all` *(fails: unexpected closing delimiter in self_improvement.rs)*
- `cargo test --all` *(fails: unexpected closing delimiter in self_improvement.rs)*
- `cargo bench --no-run` *(fails: unexpected closing delimiter in self_improvement.rs)*

------
https://chatgpt.com/codex/tasks/task_e_688fd87c4e9c83319004e9d52f192849